### PR TITLE
Add timeout to initial socket connection, fix deprecated escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0 - TBD
+
+* Fix issue where timeout was not being applied to the new connection
+* Fix various deprecated regex escape patterns
+
+
 ## 0.1.1 - 2018-09-14
 
 * Fix initial negotiate message not setting connection timeout value

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 setup(
     name='smbprotocol',
-    version='0.1.1',
+    version='0.2.0',
     packages=['smbprotocol'],
     install_requires=[
         'cryptography>=2.0',

--- a/smbprotocol/connection.py
+++ b/smbprotocol/connection.py
@@ -832,7 +832,7 @@ class Connection(object):
             negotiation process to complete
         """
         log.info("Setting up transport connection")
-        self.transport.connect()
+        self.transport.connect(timeout=timeout)
 
         log.info("Starting negotiation with SMB server")
         smb_response = self._send_smb2_negotiate(dialect, timeout)

--- a/smbprotocol/open.py
+++ b/smbprotocol/open.py
@@ -883,8 +883,7 @@ class Open(object):
         Directory, or Printer
 
         :param tree: The Tree (share) the file is located in.
-        :param name: The name of the file, excluding the share path, e.g.
-            \\server\share\folder\file.txt would be folder\file.txt
+        :param name: The name of the file, excluding the share path.
         """
         # properties available based on the file itself
         self._connected = False

--- a/smbprotocol/transport.py
+++ b/smbprotocol/transport.py
@@ -54,9 +54,10 @@ class Tcp(object):
         self._connected = False
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-    def connect(self):
+    def connect(self, timeout=None):
         if not self._connected:
             log.info("Connecting to DirectTcp socket")
+            self._sock.settimeout(timeout)
             self._sock.connect((self.server, self.port))
             self._sock.setblocking(0)
             self._connected = True

--- a/smbprotocol/tree.py
+++ b/smbprotocol/tree.py
@@ -177,9 +177,8 @@ class TreeConnect(object):
         3.2.1.4 Per Tree Connect
         Attributes per Tree Connect (share connections)
 
-        :param session: The Session to connect to the tree with
-        :param share_name: The name of the share, including the server name,
-            e.g. \\server\share
+        :param session: The Session to connect to the tree with.
+        :param share_name: The name of the share, including the server name.
         """
         self._connected = False
         self.open_table = {}


### PR DESCRIPTION
Trying to connect to a host that was routable but the SMB port was blocked would hang the process. This PR makes sure the initial socket connection honours the connection timeout set.

It also fixes up some deprecated escape sequences that Python 3.8 was warning about.