### PR TITLE
Add Windows SSPI support and use newer NTLM class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fix issue where timeout was not being applied to the new connection
 * Fix various deprecated regex escape patterns
+* Added support for Windows Kerberos and implicit credential support through the optional extra library [pywin32](https://github.com/mhammond/pywin32)
+* Simplified the fallback NTLM context object
 
 
 ## 0.1.1 - 2018-09-14

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ backlog for features that would be nice to have in this library.
 ## Requirements
 
 * Python 2.6, 2.7, 3.4+
-* For Kerberos auth [python-gssapi](https://github.com/pythongssapi/python-gssapi)
+* For Kerberos auth
+    * [python-gssapi](https://github.com/pythongssapi/python-gssapi) on Linux
+    * [pywin32](https://github.com/mhammond/pywin32) on Windows
 
 To use Kerberos authentication, further dependencies are required, to install
 these dependencies run
@@ -46,12 +48,13 @@ sudo yum install gcc python-devel krb5-devel krb5-workstation python-devel
 pip install smbprotocol[kerberos]
 ```
 
-Currently Kerberos authentication is not supported on Windows. As part of this
-optional extra, the python-gssapi library is installed and smbprotocol requires
-a particular GSSAPI extension to be available to work. This extension should
-be installed on the majority of MIT or Heimdall Kerberos installs but it isn't
-guaranteed. To verify that Kerberos is available you can run the following
-check in a Python console
+Kerberos auth with Windows just requires the `pywin32` package to be installed
+and the Windows host to be joined to that domain. On Linux the python-gssapi
+library must be installed and smbprotocol requires a particular GSSAPI
+extension to be available to work. This extension should be installed on the
+majority of MIT or Heimdal Kerberos installs but it isn't guaranteed. To
+verify that Kerberos is available on Linux you can run the following check in
+a Python console:
 
 ```
 try:
@@ -73,7 +76,7 @@ To install smbprotocol, simply run
 ```
 pip install smbprotocol
 
-# on a non Windows host, to install with Kerberos support
+# To install with Kerberos support
 pip install smbprotocol[kerberos]
 ```
 
@@ -204,7 +207,6 @@ docker run -d -p $SMB_PORT:445 -v $(pwd)/build-scripts:/app -w /app -e SMB_USER=
 Here is a list of features that I would like to incorporate, PRs are welcome
 if you want to implement them yourself;
 
-* SSPI integration for Windows and Kerberos authentication
 * Test and support DFS mounts and not just server shares
 * Multiple channel support to speed up large data transfers
 * Create an easier API on top of the `raw` SMB calls that currently exist

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,14 @@ install:
 - cmd: pip install -r requirements-test.txt
 - cmd: pip install .
 
+# test out pywin32 on some matrixes
+- ps: |
+    $ErrorActionPreference = "SilentlyContinue"
+    if ($env:PYTHON -in @("Python27", "Python27-x64", "Python36", "Python36-x64")) {
+        pip install .[kerberos]
+    }
+    $ErrorActionPreference = "Stop"
+
 build: off  # Do not run MSBuild, build stuff at install step
 
 test_script:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=['smbprotocol'],
     install_requires=[
         'cryptography>=2.0',
-        'ntlm-auth',
+        'ntlm-auth>=1.2.0',
         'pyasn1',
         'six',
     ],
@@ -26,7 +26,9 @@ setup(
         ':python_version<"2.7"': [
             'ordereddict'
         ],
-        'kerberos:sys_platform=="win32"': [],
+        'kerberos:sys_platform=="win32"': [
+            'pywin32'
+        ],
         'kerberos:sys_platform!="win32"': [
             'gssapi>=1.4.1'
         ]

--- a/smbprotocol/session.py
+++ b/smbprotocol/session.py
@@ -616,10 +616,10 @@ class SSPIContext(object):
         self._call_counter = 0
 
         flags = sspicon.ISC_REQ_INTEGRITY | \
-                sspicon.ISC_REQ_CONFIDENTIALITY | \
-                sspicon.ISC_REQ_REPLAY_DETECT | \
-                sspicon.ISC_REQ_SEQUENCE_DETECT | \
-                sspicon.ISC_REQ_MUTUAL_AUTH
+            sspicon.ISC_REQ_CONFIDENTIALITY | \
+            sspicon.ISC_REQ_REPLAY_DETECT | \
+            sspicon.ISC_REQ_SEQUENCE_DETECT | \
+            sspicon.ISC_REQ_MUTUAL_AUTH
 
         domain, username = _split_username_and_domain(username)
         # We could use the MECH to derive the package name but we are just

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -122,19 +122,16 @@ class TestNtlmContext(object):
         actual = NtlmContext("username", "password")
         assert actual.domain == ""
         assert actual.username == "username"
-        assert actual.password == "password"
 
     def test_username_in_netlogon_form(self):
         actual = NtlmContext("DOMAIN\\username", "password")
         assert actual.domain == "DOMAIN"
         assert actual.username == "username"
-        assert actual.password == "password"
 
     def test_username_in_upn_form(self):
         actual = NtlmContext("username@DOMAIN.LOCAL", "password")
         assert actual.domain == ""
         assert actual.username == "username@DOMAIN.LOCAL"
-        assert actual.password == "password"
 
 
 class TestSession(object):


### PR DESCRIPTION
Adds supports for authentication with SSPI on Windows which adds the following when running on Windows;

* Implicit credentials, uses the current user's credentials, and
* Kerberos authentication

Also uses a newer class from `ntlm-auth` for better simplicity and maintained.

Implements https://github.com/jborean93/smbprotocol/issues/7