### PR TITLE
Support IPv6 and fix Lease response messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.1 - TBD
+
+* Fix issue when trying to connect to host with IPv6 address
+* Fix response parsing for SMB2 Create Response Lease V1 and V2
+* Added the ability to set the Oplock level when opening a file
+
+
 ## 0.2.0 - 2019-09-19
 
 * Fix issue where timeout was not being applied to the new connection

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 setup(
     name='smbprotocol',
-    version='0.2.0',
+    version='0.2.1',
     packages=['smbprotocol'],
     install_requires=[
         'cryptography>=2.0',

--- a/smbprotocol/create_contexts.py
+++ b/smbprotocol/create_contexts.py
@@ -195,9 +195,6 @@ class SMB2CreateContextRequest(Structure):
         return mod if mod == 0 else 8 - mod
 
     def _padding2_size(self, structure):
-        if structure['next'].get_value() == 0:
-            return 0
-
         data_length = len(structure['buffer_name']) + \
             len(structure['padding']) + len(structure['buffer_data'])
         mod = data_length % 8

--- a/smbprotocol/open.py
+++ b/smbprotocol/open.py
@@ -932,7 +932,9 @@ class Open(object):
 
     def create(self, impersonation_level, desired_access, file_attributes,
                share_access, create_disposition, create_options,
-               create_contexts=None, send=True):
+               create_contexts=None,
+               oplock_level=RequestedOplockLevel.SMB2_OPLOCK_LEVEL_NONE,
+               send=True):
         """
         This will open the file based on the input parameters supplied. Any
         file open should also be called with Open.close() when it is finished.
@@ -966,6 +968,7 @@ class Open(object):
         opening files. More details on create context request values can be
         found here https://msdn.microsoft.com/en-us/library/cc246504.aspx.
 
+        :param oplock_level: The requested oplock level of the request.
         :param send: Whether to send the request in the same call or return the
             message to the caller and the unpack function
 
@@ -975,6 +978,7 @@ class Open(object):
             it is a Structure defined in create_contexts.py
         """
         create = SMB2CreateRequest()
+        create['requested_oplock_level'] = oplock_level
         create['impersonation_level'] = impersonation_level
         create['desired_access'] = desired_access
         create['file_attributes'] = file_attributes

--- a/smbprotocol/transport.py
+++ b/smbprotocol/transport.py
@@ -51,22 +51,22 @@ class Tcp(object):
         self.send_lock = threading.Lock()
         self.recv_lock = threading.Lock()
 
-        self._connected = False
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock = None
 
     def connect(self, timeout=None):
-        if not self._connected:
+        if self._sock is None:
             log.info("Connecting to DirectTcp socket")
-            self._sock.settimeout(timeout)
-            self._sock.connect((self.server, self.port))
+            try:
+                self._sock = socket.create_connection((self.server, self.port), timeout=timeout)
+            except (OSError, socket.gaierror) as err:
+                raise ValueError("Failed to connect to '%s:%s': %s" % (self.server, self.port, str(err)))
             self._sock.setblocking(0)
-            self._connected = True
 
     def disconnect(self):
-        if self._connected:
+        if self._sock is not None:
             log.info("Disconnecting DirectTcp socket")
             self._sock.close()
-            self._connected = False
+            self._sock = None
 
     def send(self, request):
         data_length = len(request)

--- a/tests/test_create_contexts.py
+++ b/tests/test_create_contexts.py
@@ -102,12 +102,8 @@ class TestSMB2CreateContextName(object):
                    b"\x00\x00" \
                    b"\x00\x00" \
                    b"\x00\x00\x00\x00" \
-                   b"\x51\x46\x69\x64"
-
-        # has not padding on the end
-        assert len(ea_buffers) == 89
-        assert len(alloc_size_context) == 32
-        assert len(query_disk) == 20
+                   b"\x51\x46\x69\x64" \
+                   b"\x00\x00\x00\x00"
 
         actual = SMB2CreateContextRequest.pack_multiple([
             ea_buffers,
@@ -118,7 +114,7 @@ class TestSMB2CreateContextName(object):
         # now has padding on the end
         assert len(ea_buffers) == 96
         assert len(alloc_size_context) == 32
-        assert len(query_disk) == 20
+        assert len(query_disk) == 24
         assert actual == expected
 
     def test_pack_multiple_raw_context(self):
@@ -187,7 +183,8 @@ class TestSMB2CreateContextName(object):
                b"\x00\x00" \
                b"\x00\x00" \
                b"\x00\x00\x00\x00" \
-               b"\x51\x46\x69\x64"
+               b"\x51\x46\x69\x64" \
+               b"\x00\x00\x00\x00"
         data = actual1.unpack(data)
         data = actual2.unpack(data)
         data = actual3.unpack(data)
@@ -247,7 +244,7 @@ class TestSMB2CreateContextName(object):
         assert alloc['allocation_size'].get_value() == 1024
         assert actual2['padding2'].get_value() == b""
 
-        assert len(actual3) == 20
+        assert len(actual3) == 24
         assert actual3['next'].get_value() == 0
         assert actual3['name_offset'].get_value() == 16
         assert actual3['name_length'].get_value() == 4
@@ -257,7 +254,7 @@ class TestSMB2CreateContextName(object):
         assert actual3['buffer_name'].get_value() == b"\x51\x46\x69\x64"
         assert actual3['padding'].get_value() == b""
         assert actual3['buffer_data'].get_value() == b""
-        assert actual3['padding2'].get_value() == b""
+        assert actual3['padding2'].get_value() == b"\x00\x00\x00\x00"
 
     def test_get_context_data_known(self):
         message = SMB2CreateContextRequest()

--- a/tests/test_create_contexts.py
+++ b/tests/test_create_contexts.py
@@ -1,3 +1,5 @@
+import pytest
+import re
 import uuid
 
 from datetime import datetime
@@ -118,6 +120,28 @@ class TestSMB2CreateContextName(object):
         assert len(alloc_size_context) == 32
         assert len(query_disk) == 20
         assert actual == expected
+
+    def test_pack_multiple_raw_context(self):
+        alloc_size = SMB2CreateAllocationSize()
+        alloc_size['allocation_size'] = 1024
+
+        expected = b"\x00\x00\x00\x00" \
+                   b"\x10\x00" \
+                   b"\x04\x00" \
+                   b"\x00\x00" \
+                   b"\x18\x00" \
+                   b"\x08\x00\x00\x00" \
+                   b"\x41\x6c\x53\x69" \
+                   b"\x00\x00\x00\x00" \
+                   b"\x00\x04\x00\x00\x00\x00\x00\x00"
+        actual = SMB2CreateContextRequest.pack_multiple([alloc_size])
+        assert actual == expected
+
+    def test_pack_multiple_bad_message(self):
+        expected = "Invalid context message, must be either a SMB2CreateContextRequest or a predefined structure " \
+                   "object with NAME defined."
+        with pytest.raises(ValueError, match=re.escape(expected)):
+            SMB2CreateContextRequest.pack_multiple([b"\x00"])
 
     def test_parse_message(self):
         actual1 = SMB2CreateContextRequest()
@@ -592,7 +616,7 @@ class TestSMB2CreateRequestLeaseV2(object):
             LeaseRequestFlags.SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET
         message['lease_duration'] = 10
         message['parent_lease_key'] = b"\xee" * 16
-        message['epoch'] = b"\xdd" * 16
+        message['epoch'] = b"\xdd" * 2
         expected = b"\xff\xff\xff\xff\xff\xff\xff\xff" \
                    b"\xff\xff\xff\xff\xff\xff\xff\xff" \
                    b"\x01\x00\x00\x00" \
@@ -600,11 +624,10 @@ class TestSMB2CreateRequestLeaseV2(object):
                    b"\x0a\x00\x00\x00\x00\x00\x00\x00" \
                    b"\xee\xee\xee\xee\xee\xee\xee\xee" \
                    b"\xee\xee\xee\xee\xee\xee\xee\xee" \
-                   b"\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd" \
-                   b"\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd" \
+                   b"\xdd\xdd" \
                    b"\x00\x00"
         actual = message.pack()
-        assert len(message) == 66
+        assert len(message) == 52
         assert actual == expected
 
     def test_parse_message(self):
@@ -616,11 +639,10 @@ class TestSMB2CreateRequestLeaseV2(object):
                b"\x0a\x00\x00\x00\x00\x00\x00\x00" \
                b"\xee\xee\xee\xee\xee\xee\xee\xee" \
                b"\xee\xee\xee\xee\xee\xee\xee\xee" \
-               b"\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd" \
-               b"\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd" \
+               b"\xdd\xdd" \
                b"\x00\x00"
         data = actual.unpack(data)
-        assert len(actual) == 66
+        assert len(actual) == 52
         assert data == b""
         assert actual['lease_key'].get_value() == b"\xff" * 16
         assert actual['lease_state'].get_value() == \
@@ -629,7 +651,7 @@ class TestSMB2CreateRequestLeaseV2(object):
             LeaseRequestFlags.SMB2_LEASE_FLAG_PARENT_LEASE_KEY_SET
         assert actual['lease_duration'].get_value() == 10
         assert actual['parent_lease_key'].get_value() == b"\xee" * 16
-        assert actual['epoch'].get_value() == b"\xdd" * 16
+        assert actual['epoch'].get_value() == b"\xdd" * 2
         assert actual['reserved'].get_value() == 0
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,4 +1,5 @@
 import errno
+import re
 import socket
 
 import pytest
@@ -46,12 +47,19 @@ class TestTcp(object):
     def test_send_fail_non_blocking(self):
         # ensure it doesn't loop when a non blocking error is raised
         tcp = Tcp("0.0.0.0", 0)
+        tcp._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with pytest.raises(socket.error) as err:
             tcp.send(b"\x01\x02\x03\x04")
 
     def test_recv_fail_non_blocking(self):
         # ensure it doesn't loop when a non blocking error is raised
         tcp = Tcp("0.0.0.0", 0)
+        tcp._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         with pytest.raises(socket.error) as err:
             tcp._recv(10)
         assert err.value.errno == errno.ENOTCONN
+
+    def test_invalid_host(self):
+        tcp = Tcp("fake-host", 445)
+        with pytest.raises(ValueError, match=re.escape("Failed to connect to 'fake-host:445': ")):
+            tcp.connect()


### PR DESCRIPTION
Fixes up the socket connection to support IPv6 addresses. Also fixes up the create response parsing when receiving a lease response.

Fixes https://github.com/jborean93/smbprotocol/issues/11
Fixes https://github.com/jborean93/pypsexec/issues/17