### PR TITLE
Drop support for Python 2.6, added 3.8 to CI officially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ sudo: required
 
 language: python
 
-dist: xenial
+dist: bionic
 
 matrix:
   include:
-  - python: 2.6
-    dist: trusty
   - python: 2.7
   - python: 3.4
     dist: trusty
@@ -15,12 +13,7 @@ matrix:
     dist: trusty
   - python: 3.6
   - python: 3.7
-  - python: 3.8-dev
-
-  # 3.8 is still a beta and I'm running it to see if anything breaks but
-  # don't want it to stop the build
-  allow_failures:
-  - python: 3.8-dev
+  - python: 3.8
 
 services:
 - docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.1 - TBD
 
+* Drop support for Python 2.6
 * Fix issue when trying to connect to host with IPv6 address
 * Fix response parsing for SMB2 Create Response Lease V1 and V2
 * Added the ability to set the Oplock level when opening a file

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
             'gssapi>=1.4.1'
         ]
     },
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     author='Jordan Borean',
     author_email='jborean93@gmail.com',
     url='https://github.com/jborean93/smbprotocol',
@@ -44,12 +45,12 @@ setup(
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35,py36,py37
+envlist = py27,py34,py35,py36,py37,py38
 
 [testenv]
 deps= -rrequirements-test.txt


### PR DESCRIPTION
Drop Python 2.6 support and added Python 3.8 officially to the Travis CI list.