### PR TITLE
New Listener and FileSystemWatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ ENV/
 
 # MacOS File
 .DS_Store
+
+# Vagrant test files
+build-scripts/.vagrant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## 0.2.1 - TBD
+## 0.3.0 - TBD
 
 * Drop support for Python 2.6
 * Fix issue when trying to connect to host with IPv6 address
 * Fix response parsing for SMB2 Create Response Lease V1 and V2
 * Added the ability to set the Oplock level when opening a file
+* Revamped the socket listener and message processor to run in a separate thread for better concurrency
+* Added the `FileSystemWatcher` in `change_notify.py` to provider a way to watch for changes on the SMB filesystem
+* Added the `.cancel()` method onto a Request to cancel an SMB request on the server
 
 
 ## 0.2.0 - 2019-09-19

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ build: off  # Do not run MSBuild, build stuff at install step
 
 test_script:
 #- cmd: py.test -v --pep8 --cov smbprotocol --cov-report term-missing
-- cmd: echo hi
+- cmd: echo howdy
 
 on_finish:
 - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,8 +35,7 @@ init:
     New-SmbShare -Name "$($env:SMB_SHARE)-encrypted" -Path C:\share-encrypted -EncryptData $true -FullAccess Everyone > $null
 
     $env:SMB_USER = $($env:USERNAME)
-    #$env:SMB_PASSWORD = [Microsoft.Win32.Registry]::GetValue("HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon", "DefaultPassword", '')
-    $env:SMB_PASSWORD = $env:APPVEYOR_RDP_PASSWORD
+    $env:SMB_PASSWORD = [Microsoft.Win32.Registry]::GetValue("HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon", "DefaultPassword", '')
 
     Set-SmbServerConfiguration -RequireSecuritySignature $true -Force
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,18 +10,19 @@ environment:
     SMB_SERVER: 127.0.0.1
     SMB_SHARE: share
     SMB_PORT: 445
+    APPVEYOR_RDP_PASSWORD: SuperSecretPassword123
   matrix:
   # https://www.appveyor.com/docs/installed-software/#python
   - PYTHON: Python27
-  - PYTHON: Python27-x64
-  - PYTHON: Python34
-  - PYTHON: Python34-x64
-  - PYTHON: Python35
-  - PYTHON: Python35-x64
-  - PYTHON: Python36
-  - PYTHON: Python36-x64
-  - PYTHON: Python37
-  - PYTHON: Python37-x64
+  #- PYTHON: Python27-x64
+  #- PYTHON: Python34
+  #- PYTHON: Python34-x64
+  #- PYTHON: Python35
+  #- PYTHON: Python35-x64
+  #- PYTHON: Python36
+  #- PYTHON: Python36-x64
+  #- PYTHON: Python37
+  #- PYTHON: Python37-x64
 
 init:
 - ps: |
@@ -35,9 +36,11 @@ init:
     New-SmbShare -Name "$($env:SMB_SHARE)-encrypted" -Path C:\share-encrypted -EncryptData $true -FullAccess Everyone > $null
 
     $env:SMB_USER = $($env:USERNAME)
-    $env:SMB_PASSWORD = [Microsoft.Win32.Registry]::GetValue("HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon", "DefaultPassword", '')
+    #$env:SMB_PASSWORD = [Microsoft.Win32.Registry]::GetValue("HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon", "DefaultPassword", '')
+    $env:SMB_PASSWORD = $env:APPVEYOR_RDP_PASSWORD
 
     Set-SmbServerConfiguration -RequireSecuritySignature $true -Force
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
 - cmd: python -m pip install --upgrade pip
@@ -56,4 +59,8 @@ install:
 build: off  # Do not run MSBuild, build stuff at install step
 
 test_script:
-- cmd: py.test -v --pep8 --cov smbprotocol --cov-report term-missing
+#- cmd: py.test -v --pep8 --cov smbprotocol --cov-report term-missing
+- cmd: echo hi
+
+on_finish:
+- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-# Windows Server 2016
-image: Visual Studio 2017
+# Windows Server 2019
+image: Visual Studio 2019
 
 environment:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,19 +10,18 @@ environment:
     SMB_SERVER: 127.0.0.1
     SMB_SHARE: share
     SMB_PORT: 445
-    APPVEYOR_RDP_PASSWORD: SuperSecretPassword123
   matrix:
   # https://www.appveyor.com/docs/installed-software/#python
   - PYTHON: Python27
-  #- PYTHON: Python27-x64
-  #- PYTHON: Python34
-  #- PYTHON: Python34-x64
-  #- PYTHON: Python35
-  #- PYTHON: Python35-x64
-  #- PYTHON: Python36
-  #- PYTHON: Python36-x64
-  #- PYTHON: Python37
-  #- PYTHON: Python37-x64
+  - PYTHON: Python27-x64
+  - PYTHON: Python34
+  - PYTHON: Python34-x64
+  - PYTHON: Python35
+  - PYTHON: Python35-x64
+  - PYTHON: Python36
+  - PYTHON: Python36-x64
+  - PYTHON: Python37
+  - PYTHON: Python37-x64
 
 init:
 - ps: |
@@ -40,7 +39,6 @@ init:
     $env:SMB_PASSWORD = $env:APPVEYOR_RDP_PASSWORD
 
     Set-SmbServerConfiguration -RequireSecuritySignature $true -Force
-- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
 - cmd: python -m pip install --upgrade pip
@@ -59,8 +57,4 @@ install:
 build: off  # Do not run MSBuild, build stuff at install step
 
 test_script:
-#- cmd: py.test -v --pep8 --cov smbprotocol --cov-report term-missing
-- cmd: echo howdy
-
-on_finish:
-- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+- cmd: py.test -v --pep8 --cov smbprotocol --cov-report term-missing

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 setup(
     name='smbprotocol',
-    version='0.2.1',
+    version='0.3.0',
     packages=['smbprotocol'],
     install_requires=[
         'cryptography>=2.0',

--- a/smbprotocol/_text.py
+++ b/smbprotocol/_text.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+import six
+
+
+def to_bytes(value, encoding='utf-8'):
+    """
+    Makes sure the value is encoded as a byte string.
+    :param value: The Python string value to encode.
+    :param encoding: The encoding to use.
+    :return: The byte string that was encoded.
+    """
+    if isinstance(value, six.binary_type):
+        return value
+    return value.encode(encoding)
+
+
+def to_text(value, encoding='utf-8'):
+    """
+    Makes sure the value is decoded as a text string.
+    :param value: The Python byte string value to decode.
+    :param encoding: The encoding to use.
+    :return: The text/unicode string that was decoded.
+    """
+    if isinstance(value, six.text_type):
+        return value
+    return value.decode(encoding)
+
+
+# On Python 2 a native string is a byte string and on Python 3 a native string is a text (unicode) string.
+if six.PY2:  # pragma: no cover
+    to_native = to_bytes
+else:  # pragma: no cover
+    to_native = to_text

--- a/smbprotocol/change_notify.py
+++ b/smbprotocol/change_notify.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+import logging
+import threading
+
+from smbprotocol.connection import (
+    Commands,
+    NtStatus,
+)
+
+from smbprotocol.exceptions import (
+    SMBResponseException,
+)
+
+from smbprotocol.structure import (
+    BytesField,
+    EnumField,
+    FlagField,
+    IntField,
+    Structure,
+    TextField,
+)
+
+try:
+    from collections import OrderedDict
+except ImportError:  # pragma: no cover
+    from ordereddict import OrderedDict
+
+log = logging.getLogger(__name__)
+
+
+class ChangeNotifyFlags(object):
+    """
+    [MS-SMB2] 2.2.35 SMB2 CHANGE_NOTIFY Request - Flags
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/598f395a-e7a2-4cc8-afb3-ccb30dd2df7c
+    """
+    NONE = 0
+    SMB2_WATCH_TREE = 0x0001
+
+
+class CompletionFilter(object):
+    """
+    [MS-SMB2] 2.2.35 SMB2 CHANGE_NOTIFY Request - CompletionFilter
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/598f395a-e7a2-4cc8-afb3-ccb30dd2df7c
+    """
+    FILE_NOTIFY_CHANGE_FILE_NAME = 0x00000001
+    FILE_NOTIFY_CHANGE_DIR_NAME = 0x00000002
+    FILE_NOTIFY_CHANGE_ATTRIBUTES = 0x00000004
+    FILE_NOTIFY_CHANGE_SIZE = 0x00000008
+    FILE_NOTIFY_CHANGE_LAST_WRITE = 0x00000010
+    FILE_NOTIFY_CHANGE_LAST_ACCESS = 0x00000020
+    FILE_NOTIFY_CHANGE_CREATION = 0x00000040
+    FILE_NOTIFY_CHANGE_EA = 0x00000080
+    FILE_NOTIFY_CHANGE_SECURITY = 0x00000100
+    FILE_NOTIFY_CHANGE_STREAM_NAME = 0x00000200
+    FILE_NOTIFY_CHANGE_STREAM_SIZE = 0x00000400
+    FILE_NOTIFY_CHANGE_STREAM_WRITE = 0x00000800
+
+
+class FileAction(object):
+    """
+    [MS-FSCC] 2.7.1 FILE_NOTIFY_INFORMATION - Action
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/634043d7-7b39-47e9-9e26-bda64685e4c9
+    """
+    FILE_ACTION_ADDED = 0x00000001
+    FILE_ACTION_REMOVED = 0x00000002
+    FILE_ACTION_MODIFIED = 0x00000003
+    FILE_ACTION_RENAMED_OLD_NAME = 0x00000004
+    FILE_ACTION_RENAMED_NEW_NAME = 0x00000005
+    FILE_ACTION_ADDED_STREAM = 0x00000006
+    FILE_ACTION_REMOVED_STREAM = 0x00000007
+    FILE_ACTION_MODIFIED_STREAM = 0x00000008
+    FILE_ACTION_REMOVED_BY_DELETE = 0x00000009
+    FILE_ACTION_ID_NOT_TUNNELLED = 0x0000000A
+    FILE_ACTION_TUNNELLED_ID_COLLISION = 0x0000000B
+
+
+class FileNotifyInformation(Structure):
+    """
+    [Ms-FSCC] 2.7.1 FILE_NOTIFY_INFORMATION
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/634043d7-7b39-47e9-9e26-bda64685e4c9
+    """
+    def __init__(self):
+        self.fields = OrderedDict([
+            ('next_entry_offset', IntField(size=4)),
+            ('action', EnumField(
+                size=4,
+                enum_type=FileAction,
+            )),
+            ('file_name_length', IntField(
+                size=4,
+                default=lambda s: len(s['file_name']),
+            )),
+            ('file_name', TextField(
+                encoding='utf-16-le',
+                size=lambda s: s['file_name_length'].get_value(),
+            )),
+        ])
+        super(FileNotifyInformation, self).__init__()
+
+
+class SMB2ChangeNotifyRequest(Structure):
+    """
+    [MS-SMB2] 2.2.35 SMB2 CHANGE_NOTIFY Request
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/598f395a-e7a2-4cc8-afb3-ccb30dd2df7c
+
+    Sent by the client to request change notifications on a directory.
+    """
+    COMMAND = Commands.SMB2_CHANGE_NOTIFY
+
+    def __init__(self):
+        self.fields = OrderedDict([
+            ('structure_size', IntField(
+                size=2,
+                default=32,
+            )),
+            ('flags', FlagField(
+                size=2,
+                flag_type=ChangeNotifyFlags,
+            )),
+            ('output_buffer_length', IntField(size=4)),
+            ('file_id', BytesField(size=16)),
+            ('completion_filter', FlagField(
+                size=4,
+                flag_type=CompletionFilter,
+            )),
+            ('reserved', IntField(size=4)),
+        ])
+        super(SMB2ChangeNotifyRequest, self).__init__()
+
+
+class SMB2ChangeNotifyResponse(Structure):
+    """
+    [MS-SMB2] 2.2.36 SMB2 CHANGE_NOTIFY Response
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/14f9d050-27b2-49df-b009-54e08e8bf7b5
+
+    Sent by the server to transmit the results of a client's change notify request.
+    """
+    COMMAND = Commands.SMB2_CHANGE_NOTIFY
+
+    def __init__(self):
+        self.fields = OrderedDict([
+            ('structure_size', IntField(
+                size=2,
+                default=9,
+            )),
+            ('output_buffer_offset', IntField(
+                size=2,
+                default=72,
+            )),
+            ('output_buffer_length', IntField(
+                size=4,
+                default=lambda s: len(s['buffer']),
+            )),
+            ('buffer', BytesField(
+                size=lambda s: s['output_buffer_length'].get_value(),
+            )),
+        ])
+        super(SMB2ChangeNotifyResponse, self).__init__()
+
+
+class FileSystemWatcher(object):
+
+    def __init__(self, open):
+        """
+        A class that encapsulates a FileSystemWatcher over SMB. It is designed to make it easy to run the watcher in
+        the background and provide an event that is fired when the server notifies that a change has occurred. It is
+        up to the caller to action on that event through their own sync or asynchronous implementation.
+
+        :param open: The Open() class of a directory to watch for change notifications.
+        """
+        self.open = open
+        self.response_event = threading.Event()
+
+        self._t_on_response = threading.Thread(target=self._on_response)
+        self._t_on_response.daemon = True
+        self._t_exc = None
+        self._request = None
+        self._file_actions = None
+        self._result_lock = threading.Lock()  # Used to ensure the result is only processed once
+
+    @property
+    def result(self):
+        """
+        The result of the FileSystemWatcher request after it has been completed. Returns None if it still running
+        or has been cancelled, raises the underlying exception if one was returned by the server or a list of
+        FileNotifyInformation() structures that contain all the changed details. The list is empty if the watcher's
+        output buffer length was set to 0 which indicates a change has occured but no details were returned by the
+        server.
+        """
+        if self.cancelled:
+            return None
+        if self._request is None or self._request.response is None:
+            return None
+        elif self._t_exc:
+            raise self._t_exc
+
+        with self._result_lock:
+            if self._file_actions is not None:
+                return self._file_actions
+
+            response = self._request.response['data'].get_value()
+            change_response = SMB2ChangeNotifyResponse()
+            change_response.unpack(response)
+            response_buffer = change_response['buffer'].get_value()
+
+            self._file_actions = []
+            current_offset = 0
+            is_next = True
+            while is_next:
+                notify_info = FileNotifyInformation()
+                notify_info.unpack(response_buffer[current_offset:])
+
+                self._file_actions.append(notify_info)
+
+                current_offset += notify_info['next_entry_offset'].get_value()
+                is_next = notify_info['next_entry_offset'].get_value() != 0
+
+        return self._file_actions
+
+    @property
+    def cancelled(self):
+        """ States whether the change notify request was cancelled or not. """""
+        return self._request is not None and self._request.cancelled is True
+
+    def start(self, completion_filter, flags=0, output_buffer_length=65536):
+        """
+        Starts a change notify request against the server with the options specified.
+
+        Note: cannot send as a compound request as the resulting async reply session cannot be determined. See the
+        following URL for more details.
+        https://social.msdn.microsoft.com/Forums/en-US/a580f7bc-6746-4876-83db-6ac209b202c4/mssmb2-change-notify-response-sessionid?forum=os_fileservices
+
+        :param completion_filter: Specify one or more filters to request a notification on.
+        :param flags: Specify custom flags, only ChangeNotifyFlags.SMB2_WATCH_TREE is defined which watches for change
+            events in the sub directories of the Open() dir specified.
+        :param output_buffer_length: The output buffer length to defined the max size of data the server can return.
+            Set to 0 to only receive a notification of changes without the details of the change.
+        """
+        change_notify = SMB2ChangeNotifyRequest()
+        change_notify['flags'] = flags
+        change_notify['output_buffer_length'] = output_buffer_length
+        change_notify['file_id'] = self.open.file_id
+        change_notify['completion_filter'] = completion_filter
+
+        request = self.open.connection.send(change_notify, self.open.tree_connect.session.session_id,
+                                            self.open.tree_connect.tree_connect_id)
+        self._request = request
+        self._t_on_response.start()
+
+    def cancel(self):
+        """
+        Cancels the change notify request on the server.
+        """
+        self._request.cancel()
+
+    def wait(self):
+        """
+        Waits until a change response has been returned from the server.
+
+        :return: The file action result
+        """
+        self._t_on_response.join()
+        return self.result
+
+    def _on_response(self):
+        try:
+            self.open.connection.receive(self._request)
+        except SMBResponseException as exc:
+            if exc.status == NtStatus.STATUS_CANCELLED:
+                self.is_cancelled = True
+            elif exc.status == NtStatus.STATUS_NOTIFY_ENUM_DIR:
+                # output_buffer_length was 0 so we only need to notify the caller that a change occurred, set an empty
+                # action list.
+                self._file_actions = []
+            else:
+                self._t_exc = exc
+        except Exception as exc:
+            self._t_exc = exc
+        finally:
+            self.response_event.set()

--- a/smbprotocol/change_notify.py
+++ b/smbprotocol/change_notify.py
@@ -247,6 +247,9 @@ class FileSystemWatcher(object):
         change_notify['file_id'] = self.open.file_id
         change_notify['completion_filter'] = completion_filter
 
+        log.info("Session: %s, Tree Connect: %s , Open: %s - sending SMB2 Change Notify request"
+                 % (self.open.tree_connect.session.username, self.open.tree_connect.share_name, self.open.file_name))
+        log.debug(str(change_notify))
         request = self.open.connection.send(change_notify, self.open.tree_connect.session.session_id,
                                             self.open.tree_connect.tree_connect_id)
         self._request = request
@@ -282,4 +285,5 @@ class FileSystemWatcher(object):
         except Exception as exc:
             self._t_exc = exc
         finally:
+            log.debug("Firing response event for %s change notify" % (self.open.file_name))
             self.response_event.set()

--- a/smbprotocol/change_notify.py
+++ b/smbprotocol/change_notify.py
@@ -194,6 +194,8 @@ class FileSystemWatcher(object):
             return None
         if self._request is None or self._request.response is None:
             return None
+        elif self._request.response['status'].get_value() == NtStatus.STATUS_PENDING:
+            return None
         elif self._t_exc:
             raise self._t_exc
 

--- a/smbprotocol/connection.py
+++ b/smbprotocol/connection.py
@@ -1546,6 +1546,7 @@ class Request(object):
             return
 
         message_id = self.message['message_id'].get_value()
+        log.info("Cancelling message %s" % message_id)
         self._connection.send(SMB2CancelRequest(), sid=self._session_id, credit_request=0, message_id=message_id,
                               async_id=self.async_id)
         self.cancelled = True

--- a/smbprotocol/connection.py
+++ b/smbprotocol/connection.py
@@ -8,6 +8,7 @@ import math
 import os
 import struct
 import time
+import threading
 from datetime import datetime
 from threading import Lock
 
@@ -20,6 +21,11 @@ import smbprotocol.exceptions
 from smbprotocol.structure import BytesField, DateTimeField, EnumField, \
     FlagField, IntField, ListField, Structure, StructureField, UuidField
 from smbprotocol.transport import Tcp
+
+try:
+    from queue import Queue
+except ImportError:  # pragma: no cover
+    from Queue import Queue
 
 try:
     from collections import OrderedDict
@@ -187,6 +193,8 @@ class NtStatus(object):
     """
     STATUS_SUCCESS = 0x00000000
     STATUS_PENDING = 0x00000103
+    STATUS_NOTIFY_CLEANUP = 0x0000010B
+    STATUS_NOTIFY_ENUM_DIR = 0x0000010C
     STATUS_BUFFER_OVERFLOW = 0x80000005
     STATUS_EA_LIST_INCONSISTENT = 0x80000014
     STATUS_STOPPED_ON_SYMLINK = 0x8000002D
@@ -221,10 +229,54 @@ class NtStatus(object):
     STATUS_PIPE_EMPTY = 0xC00000D9
     STATUS_INTERNAL_ERROR = 0xC00000E5
     STATUS_NOT_A_DIRECTORY = 0xC0000103
+    STATUS_CANCELLED = 0xC0000120
     STATUS_CANNOT_DELETE = 0xC0000121
     STATUS_FILE_CLOSED = 0xC0000128
     STATUS_PIPE_BROKEN = 0xC000014B
     STATUS_USER_SESSION_DELETED = 0xC0000203
+
+
+class SMB2HeaderAsync(Structure):
+    """
+    [MS-SMB2] 2.2.1.1 SMB2 Packer Header - ASYNC
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/ea4560b7-90da-4803-82b5-344754b92a79
+
+    The SMB2 Packet header for async commands.
+    """
+
+    def __init__(self):
+        self.fields = OrderedDict([
+            ('protocol_id', BytesField(
+                size=4,
+                default=b"\xfeSMB",
+            )),
+            ('structure_size', IntField(
+                size=2,
+                default=64,
+            )),
+            ('credit_charge', IntField(size=2)),
+            ('channel_sequence', IntField(size=2)),
+            ('reserved', IntField(size=2)),
+            ('command', EnumField(
+                size=2,
+                enum_type=Commands,
+            )),
+            ('credit_request', IntField(size=2)),
+            ('flags', FlagField(
+                size=4,
+                flag_type=Smb2Flags,
+            )),
+            ('next_command', IntField(size=4)),
+            ('message_id', IntField(size=8)),
+            ('async_id', IntField(size=8)),
+            ('session_id', IntField(size=8)),
+            ('signature', BytesField(
+                size=16,
+                default=b"\x00" * 16,
+            )),
+            ('data', BytesField())
+        ])
+        super(SMB2HeaderAsync, self).__init__()
 
 
 class SMB2HeaderRequest(Structure):
@@ -694,6 +746,27 @@ class SMB2Echo(Structure):
         super(SMB2Echo, self).__init__()
 
 
+class SMB2CancelRequest(Structure):
+    """
+    [MS-SMB2] 2.2.30 - SMB2 CANCEL Request
+    https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/91913fc6-4ec9-4a83-961b-370070067e63
+
+    The SMB2 CANCEL Request packet is sent by the client to cancel a previously sent message on the same SMB2 transport
+    connection.
+    """
+    COMMAND = Commands.SMB2_CANCEL
+
+    def __init__(self):
+        self.fields = OrderedDict([
+            ('structure_size', IntField(
+                size=2,
+                default=4,
+            )),
+            ('reserved', IntField(size=2)),
+        ])
+        super(SMB2CancelRequest, self).__init__()
+
+
 class SMB2TransformHeader(Structure):
     """
     [MS-SMB2] v53.0 2017-09-15
@@ -726,6 +799,14 @@ class SMB2TransformHeader(Structure):
         super(SMB2TransformHeader, self).__init__()
 
 
+def _worker_running(func):
+    """ Ensures the message worker thread is still running and hasn't failed for any reason. """
+    def wrapped(self, *args, **kwargs):
+        self._check_worker_running()
+        return func(self, *args, **kwargs)
+    return wrapped
+
+
 class Connection(object):
 
     def __init__(self, guid, server_name, port=445, require_signing=True):
@@ -748,7 +829,7 @@ class Connection(object):
                  % (guid, require_signing, server_name, port))
         self.server_name = server_name
         self.port = port
-        self.transport = Tcp(server_name, port)
+        self.transport = None  # Instanciated in .connect()
 
         # Table of Session entries
         self.session_table = {}
@@ -817,6 +898,9 @@ class Connection(object):
         # same order if running in multiple threads
         self.lock = Lock()
 
+        # Keep track of the message processing thread's potential traceback that it may raise.
+        self._t_exc = None
+
     def connect(self, dialect=None, timeout=60):
         """
         Will connect to the target server and negotiate the capabilities
@@ -832,7 +916,12 @@ class Connection(object):
             negotiation process to complete
         """
         log.info("Setting up transport connection")
-        self.transport.connect(timeout=timeout)
+        message_queue = Queue()
+        self.transport = Tcp(self.server_name, self.port, message_queue, timeout)
+        t_worker = threading.Thread(target=self._process_message_thread, args=(message_queue,),
+                                    name="msg_worker-%s%s" % (self.server_name, self.port))
+        t_worker.daemon = True
+        t_worker.start()
 
         log.info("Starting negotiation with SMB server")
         smb_response = self._send_smb2_negotiate(dialect, timeout)
@@ -904,9 +993,10 @@ class Connection(object):
                 session.disconnect(True)
 
         log.info("Disconnecting transport connection")
-        self.transport.disconnect()
+        self.transport.close()
 
-    def send(self, message, sid=None, tid=None, credit_request=None):
+    @_worker_running
+    def send(self, message, sid=None, tid=None, credit_request=None, message_id=None, async_id=None):
         """
         Will send a message to the server that is passed in. The final
         unencrypted header is returned to the function that called this.
@@ -916,10 +1006,12 @@ class Connection(object):
         :param tid: A tree_id object that the message is sent for
         :param credit_request: Specifies extra credits to be requested with the
             SMB header
+        :param message_id: The message_id for the header, only useful for a cancel request.
+        :param async_id: The async_id for the header, only useful for a cancel request.
         :return: Request of the message that was sent
         """
-        header = self._generate_packet_header(message, sid, tid,
-                                              credit_request)
+        header = self._generate_packet_header(message, sid, tid, credit_request, message_id=message_id,
+                                              async_id=async_id)
 
         # get the actual Session and TreeConnect object instead of the IDs
         session = self.session_table.get(sid, None) if sid else None
@@ -927,15 +1019,17 @@ class Connection(object):
         tree = None
         if tid and session:
             if tid not in session.tree_connect_table.keys():
-                error_msg = "Cannot find Tree with the ID %d in the session " \
-                            "tree table" % tid
+                error_msg = "Cannot find Tree with the ID %d in the session tree table" % tid
                 raise smbprotocol.exceptions.SMBException(error_msg)
             tree = session.tree_connect_table[tid]
 
         if session and session.signing_required and session.signing_key:
             self._sign(header, session)
-        request = Request(header)
-        self.outstanding_requests[header['message_id'].get_value()] = request
+
+        request = None
+        if message.COMMAND != Commands.SMB2_CANCEL:
+            request = Request(header, self, session_id=sid)
+            self.outstanding_requests[header['message_id'].get_value()] = request
 
         send_data = header.pack()
         if (session and session.encrypt_data) or (tree and tree.encrypt_data):
@@ -943,8 +1037,10 @@ class Connection(object):
 
         self.transport.send(send_data)
 
-        return request
+        if message.COMMAND != Commands.SMB2_CANCEL:
+            return request
 
+    @_worker_running
     def send_compound(self, messages, sid, tid, related=False):
         """
         Sends multiple messages within 1 TCP request, will fail if the size
@@ -989,7 +1085,7 @@ class Connection(object):
                 self._sign(header, session, padding=padding)
             send_data += header.pack() + padding
 
-            request = Request(header)
+            request = Request(header, self, session_id=sid)
             requests.append(request)
             self.outstanding_requests[header['message_id'].get_value()] = \
                 request
@@ -1001,6 +1097,7 @@ class Connection(object):
 
         return requests
 
+    @_worker_running
     def receive(self, request, wait=True, timeout=None):
         """
         Polls the message buffer of the TCP connection and waits until a valid
@@ -1015,26 +1112,27 @@ class Connection(object):
         :return: SMB2HeaderResponse of the received message
         """
         start_time = time.time()
-
-        # check if we have received a response
         while True:
-            self._flush_message_buffer()
-            status = request.response['status'].get_value() if \
-                request.response else None
-            if status is not None and (wait and
-                                       status != NtStatus.STATUS_PENDING):
-                break
-            current_time = time.time() - start_time
-            if timeout and (current_time > timeout):
-                error_msg = "Connection timeout of %d seconds exceeded while" \
-                            " waiting for a response from the server" \
-                            % timeout
-                raise smbprotocol.exceptions.SMBException(error_msg)
+            iter_timeout = int(max(timeout - (time.time() - start_time), 1)) if timeout is not None else None
+            if not request.response_event.wait(timeout=iter_timeout):
+                raise smbprotocol.exceptions.SMBException("Connection timeout of %d seconds exceeded while waiting "
+                                                          "for a response from the server" % timeout)
 
-        response = request.response
-        status = response['status'].get_value()
-        if status not in [NtStatus.STATUS_SUCCESS, NtStatus.STATUS_PENDING]:
-            raise smbprotocol.exceptions.SMBResponseException(response, status)
+            # Use a lock on the request so that in the case of a pending response we have exclusive lock on the event
+            # flag and can clear it without the future pending response taking it over before we first clear the flag.
+            with request.response_lock:
+                self._check_worker_running()  # The worker may have failed while waiting for the response, check again
+
+                response = request.response
+                status = response['status'].get_value()
+                if status == NtStatus.STATUS_PENDING and wait:
+                    # Received a pending message, clear the response_event flag and wait again.
+                    request.response_event.clear()
+                    continue
+                elif status not in [NtStatus.STATUS_SUCCESS, NtStatus.STATUS_PENDING]:
+                    raise smbprotocol.exceptions.SMBResponseException(response, status)
+                else:
+                    break
 
         # now we have a retrieval request for the response, we can delete
         # the request from the outstanding requests
@@ -1075,102 +1173,109 @@ class Connection(object):
 
         return response['credit_response'].get_value()
 
-    def _generate_packet_header(self, message, session_id, tree_id,
-                                credit_request):
+    def _generate_packet_header(self, message, session_id, tree_id, credit_request, message_id=None, async_id=None):
         # when run in a thread or subprocess, getting the message id and
         # adjusting the sequence window is important so we acquire a lock to
         # ensure only one is run at a point in time
-        self.lock.acquire()
-        try:
+        with self.lock:
             sequence_window_low = self.sequence_window['low']
             sequence_window_high = self.sequence_window['high']
             credit_charge = self._calculate_credit_charge(message)
             credits_available = sequence_window_high - sequence_window_low
             if credit_charge > credits_available:
-                error_msg = "Request requires %d credits but only %d " \
-                            "credits are available" \
+                error_msg = "Request requires %d credits but only %d credits are available" \
                             % (credit_charge, credits_available)
                 raise smbprotocol.exceptions.SMBException(error_msg)
 
-            message_id = sequence_window_low
-            self.sequence_window['low'] += \
-                credit_charge if credit_charge > 0 else 1
-        finally:
-            self.lock.release()
+            if message_id is None:
+                message_id = sequence_window_low
+                self.sequence_window['low'] += credit_charge if credit_charge > 0 else 1
 
-        header = SMB2HeaderRequest()
+        if async_id is None:
+            header = SMB2HeaderRequest()
+
+            header['tree_id'] = tree_id if tree_id else 0
+        else:
+            header = SMB2HeaderAsync()
+            header['flags'].set_flag(Smb2Flags.SMB2_FLAGS_ASYNC_COMMAND)
+            header['async_id'] = async_id
+
         header['credit_charge'] = credit_charge
         header['command'] = message.COMMAND
-        header['credit_request'] = \
-            credit_request if credit_request else credit_charge
+        header['credit_request'] = credit_request if credit_request else credit_charge
         header['message_id'] = message_id
-        header['tree_id'] = tree_id if tree_id else 0
         header['session_id'] = session_id if session_id else 0
 
         # we log before adding the data to avoid polluting the logs with
         # too much info
-        log.info("Created SMB Packet Header for %s request"
-                 % str(header['command']))
+        log.info("Created SMB Packet Header for %s request" % str(header['command']))
         log.debug(str(header))
 
         header['data'] = message
 
         return header
 
-    def _flush_message_buffer(self):
-        """
-        Loops through the transport message_buffer until there are no messages
-        left in the queue. Each response is assigned to the Request object
-        based on the message_id which are then available in
-        self.outstanding_requests
-        """
+    def _check_worker_running(self):
+        """ Checks that the message worker thread is still running and raises it's exception if it has failed. """
+        if self._t_exc is not None:
+            self.transport.close()
+            raise self._t_exc
+
+    def _process_message_thread(self, msg_queue):
         while True:
-            message_bytes = self.transport.receive()
+            b_msg = msg_queue.get()
 
-            # there were no messages receives, so break from the loop
-            if message_bytes is None:
-                break
+            # The socket will put None in the queue if it is closed, signalling the end of the connection.
+            if b_msg is None:
+                return
 
-            # check if the message is encrypted and decrypt if necessary
-            if message_bytes[:4] == b"\xfdSMB":
-                message = SMB2TransformHeader()
-                message.unpack(message_bytes)
-                message_bytes = self._decrypt(message)
+            try:
+                if b_msg[:4] == b"\xfdSMB":
+                    msg = SMB2TransformHeader()
+                    msg.unpack(b_msg)
+                    b_msg = self._decrypt(msg)
 
-            # now retrieve message(s) from response
-            is_last = False
-            session_id = None
-            while not is_last:
-                next_command = struct.unpack("<L", message_bytes[20:24])[0]
-                header_length = \
-                    next_command if next_command != 0 else len(message_bytes)
-                header_bytes = message_bytes[:header_length]
-                message = SMB2HeaderResponse()
-                message.unpack(header_bytes)
+                next_command = -1
+                session_id = None
+                while next_command != 0:
+                    next_command = struct.unpack("<L", b_msg[20:24])[0]
+                    header_length = next_command if next_command != 0 else len(b_msg)
+                    b_header = b_msg[:header_length]
+                    b_msg = b_msg[header_length:]
 
-                flags = message['flags']
-                if not flags.has_flag(Smb2Flags.SMB2_FLAGS_RELATED_OPERATIONS):
-                    session_id = message['session_id'].get_value()
+                    msg = SMB2HeaderResponse()
+                    msg.unpack(b_header)
+                    if not msg['flags'].has_flag(Smb2Flags.SMB2_FLAGS_RELATED_OPERATIONS):
+                        session_id = msg['session_id'].get_value()
 
-                self._verify(message, session_id)
-                message_id = message['message_id'].get_value()
-                request = self.outstanding_requests.get(message_id, None)
-                if not request:
-                    error_msg = "Received response with an unknown message " \
-                                "ID: %d" % message_id
-                    raise smbprotocol.exceptions.SMBException(error_msg)
+                    self._verify(msg, session_id)
 
-                # add the upper credit limit based on the credits granted by
-                # the server
-                credit_response = message['credit_response'].get_value()
-                self.sequence_window['high'] += \
-                    credit_response if credit_response > 0 else 1
+                    # add the upper credit limit based on the credits granted by
+                    # the server
+                    credit_response = msg['credit_response'].get_value()
+                    self.sequence_window['high'] += credit_response if credit_response > 0 else 1
 
-                request.response = message
-                self.outstanding_requests[message_id] = request
+                    message_id = msg['message_id'].get_value()
+                    request = self.outstanding_requests[message_id]
 
-                message_bytes = message_bytes[header_length:]
-                is_last = next_command == 0
+                    # Ensure we don't step on the receive() func in the main thread processing the pending result if
+                    # already set as that will clear the response_event flag then wait again.
+                    with request.response_lock:
+                        if msg['flags'].has_flag(Smb2Flags.SMB2_FLAGS_ASYNC_COMMAND):
+                            request.async_id = msg['reserved'].pack() + msg['tree_id'].pack()
+                        request.response = msg
+                        request.response_event.set()
+            except Exception as exc:
+                # The exception is raised in _check_worker_running by the main thread when send/receive is called next.
+                self._t_exc = exc
+
+                # Make sure we fire all the request events to ensure the main thread isn't waiting on a receive.
+                for request in self.outstanding_requests.values():
+                    request.response_event.set()
+
+                # While a caller of send/receive could theoretically catch this exception, we consider any failures
+                # here a fatal errors and the connection should be closed so we exit the worker thread.
+                return
 
     def _sign(self, message, session, padding=None):
         message['flags'].set_flag(Smb2Flags.SMB2_FLAGS_SIGNED)
@@ -1381,7 +1486,7 @@ class Connection(object):
         """
         credit_size = 65536
 
-        if not self.supports_multi_credit:
+        if (not self.supports_multi_credit) or (message.COMMAND == Commands.SMB2_CANCEL):
             credit_charge = 0
         elif message.COMMAND == Commands.SMB2_READ:
             max_size = message['length'].get_value() + \
@@ -1410,7 +1515,7 @@ class Connection(object):
 
 class Request(object):
 
-    def __init__(self, message):
+    def __init__(self, message, connection, session_id=None):
         """
         [MS-SMB2] v53.0 2017-09-15
 
@@ -1419,11 +1524,28 @@ class Request(object):
         :param message: The message to be sent in the request
         """
         self.cancel_id = os.urandom(8)
-        self.async_id = os.urandom(8)
+        self.async_id = None
         self.message = message
         self.timestamp = datetime.now()
 
-        # not in SMB spec
+        # The following are not in the SMB spec but used by various functions in smbprotocol
         # Used to contain the corresponding response from the server as the
-        # receiving in done in parallel
+        # receiving in done in a separate thread
         self.response = None
+        self.response_lock = threading.Lock()
+        self.response_event = threading.Event()
+        self.cancelled = False
+
+        self._connection = connection
+
+        # Cannot rely on the message values as it could be a related compound msg which does not set these values.
+        self._session_id = session_id
+
+    def cancel(self):
+        if self.cancelled is True:
+            return
+
+        message_id = self.message['message_id'].get_value()
+        self._connection.send(SMB2CancelRequest(), sid=self._session_id, credit_request=0, message_id=message_id,
+                              async_id=self.async_id)
+        self.cancelled = True

--- a/smbprotocol/transport.py
+++ b/smbprotocol/transport.py
@@ -76,6 +76,7 @@ class Tcp(object):
     def close(self):
         if self._sock is not None:
             log.info("Disconnecting DirectTcp socket")
+            self._sock.shutdown(socket.SHUT_RD)
             self._sock.close()
             self._sock = None
             self._t_recv.join()
@@ -100,6 +101,10 @@ class Tcp(object):
         while True:
             try:
                 b_packet_size = self._sock.recv(4)
+                # Python 2 seems to return an empty byte string instead of EBADF
+                if b_packet_size == b"":
+                    return
+
                 packet_size = struct.unpack(">L", b_packet_size)[0]
                 buffer = self._sock.recv(packet_size)
             except socket.error as err:

--- a/smbprotocol/transport.py
+++ b/smbprotocol/transport.py
@@ -109,7 +109,7 @@ class Tcp(object):
                 buffer = self._sock.recv(packet_size)
             except socket.error as err:
                 # If the socket is closed send None to the msg worker to tell it to stop.
-                if err.errno == errno.EBADF:
+                if err.errno in [errno.EBADF, errno.ECONNABORTED]:
                     self._recv_queue.put(None)
                     return
                 raise

--- a/tests/test_change_notify.py
+++ b/tests/test_change_notify.py
@@ -1,0 +1,374 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+import re
+import threading
+import uuid
+
+import pytest
+
+from smbprotocol._text import (
+    to_native,
+)
+
+from smbprotocol.connection import (
+    Connection,
+)
+
+from smbprotocol.exceptions import (
+    SMBResponseException,
+)
+
+from smbprotocol.session import Session
+from smbprotocol.tree import TreeConnect
+
+from smbprotocol.change_notify import (
+    CompletionFilter,
+    FileAction,
+    FileNotifyInformation,
+    FileSystemWatcher,
+    SMB2ChangeNotifyRequest,
+    SMB2ChangeNotifyResponse,
+)
+
+from smbprotocol.open import (
+    CreateDisposition,
+    CreateOptions,
+    DirectoryAccessMask,
+    FileAttributes,
+    FilePipePrinterAccessMask,
+    ImpersonationLevel,
+    ShareAccess,
+    Open
+)
+
+from .utils import smb_real
+
+
+class TestFileNotifyInformation(object):
+
+    DATA = b"\x00\x00\x00\x00" \
+           b"\x01\x00\x00\x00" \
+           b"\x08\x00\x00\x00" \
+           b"\x63\x00\x61\x00\x66\x00\xe9\x00"
+
+    def test_create_message(self):
+        message = FileNotifyInformation()
+        message['action'] = 1
+        message['file_name'] = u"café"
+        actual = message.pack()
+        assert len(message) == 20
+        assert actual == self.DATA
+        assert str(message['file_name']) == to_native(u"café")
+
+    def test_parse_message(self):
+        actual = FileNotifyInformation()
+        assert actual.unpack(self.DATA) == b""
+        assert len(actual) == 20
+        assert actual['next_entry_offset'].get_value() == 0
+        assert actual['action'].get_value() == 1
+        assert actual['file_name_length'].get_value() == 8
+        assert actual['file_name'].get_value() == u"café"
+
+
+class TestSMB2ChangeNotifyRequest(object):
+
+    DATA = b"\x20\x00" \
+           b"\x00\x00" \
+           b"\x08\x00\x00\x00" \
+           b"\xff\xff\xff\xff\xff\xff\xff\xff" \
+           b"\xff\xff\xff\xff\xff\xff\xff\xff" \
+           b"\x01\x00\x00\x00" \
+           b"\x00\x00\x00\x00"
+
+    def test_create_message(self):
+        message = SMB2ChangeNotifyRequest()
+        message['output_buffer_length'] = 8
+        message['file_id'] = b"\xff" * 16
+        message['completion_filter'] = 1
+        actual = message.pack()
+        assert len(message) == 32
+        assert actual == self.DATA
+
+    def test_parse_message(self):
+        actual = SMB2ChangeNotifyRequest()
+        assert actual.unpack(self.DATA) == b""
+        assert len(actual) == 32
+        assert actual['structure_size'].get_value() == 32
+        assert actual['flags'].get_value() == 0
+        assert actual['output_buffer_length'].get_value() == 8
+        assert actual['file_id'].get_value() == b"\xff" * 16
+        assert actual['completion_filter'].get_value() == 1
+        assert actual['reserved'].get_value() == 0
+
+
+class TestSMB2ChangeNotifyResponse(object):
+
+    DATA = b"\x09\x00" \
+           b"\x48\x00" \
+           b"\x04\x00\x00\x00" \
+           b"\x01\x02\x03\x04"
+
+    def test_create_message(self):
+        message = SMB2ChangeNotifyResponse()
+        message['buffer'] = b"\x01\x02\x03\x04"
+        actual = message.pack()
+        assert len(message) == 12
+        assert actual == self.DATA
+
+    def test_parse_message(self):
+        actual = SMB2ChangeNotifyResponse()
+        assert actual.unpack(self.DATA) == b""
+        assert len(actual) == 12
+        assert actual['structure_size'].get_value() == 9
+        assert actual['output_buffer_offset'].get_value() == 72
+        assert actual['output_buffer_length'].get_value() == 4
+        assert actual['buffer'].get_value() == b"\x01\x02\x03\x04"
+
+
+class TestChangeNotify(object):
+
+    def _remove_file(self, tree, name):
+        file_open = Open(tree, name)
+        file_open.create(
+            ImpersonationLevel.Impersonation,
+            FilePipePrinterAccessMask.DELETE,
+            FileAttributes.FILE_ATTRIBUTE_NORMAL,
+            ShareAccess.FILE_SHARE_READ |
+            ShareAccess.FILE_SHARE_WRITE |
+            ShareAccess.FILE_SHARE_DELETE,
+            CreateDisposition.FILE_OPEN_IF,
+            CreateOptions.FILE_NON_DIRECTORY_FILE | CreateOptions.FILE_DELETE_ON_CLOSE
+        ),
+        file_open.close()
+
+    def test_change_notify_on_dir(self, smb_real):
+        connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
+        connection.connect()
+        session = Session(connection, smb_real[0], smb_real[1])
+        tree = TreeConnect(session, smb_real[4])
+        open = Open(tree, "directory-watch")
+        try:
+            session.connect()
+            tree.connect()
+
+            open.create(ImpersonationLevel.Impersonation,
+                        DirectoryAccessMask.MAXIMUM_ALLOWED,
+                        FileAttributes.FILE_ATTRIBUTE_DIRECTORY,
+                        ShareAccess.FILE_SHARE_READ |
+                        ShareAccess.FILE_SHARE_WRITE |
+                        ShareAccess.FILE_SHARE_DELETE,
+                        CreateDisposition.FILE_OPEN_IF,
+                        CreateOptions.FILE_DIRECTORY_FILE)
+
+            self._remove_file(tree, "directory-watch\\created file")
+
+            watcher = FileSystemWatcher(open)
+            watcher.start(CompletionFilter.FILE_NOTIFY_CHANGE_FILE_NAME)
+            assert watcher.result is None
+            assert watcher.response_event.is_set() is False
+
+            # Run the wait in a separate thread so we can create the dir
+            def watcher_wait():
+                watcher.wait()
+            watcher_wait_thread = threading.Thread(target=watcher_wait)
+            watcher_wait_thread.daemon = True
+            watcher_wait_thread.start()
+
+            def watcher_event():
+                watcher.response_event.wait()
+            watcher_event_thread = threading.Thread(target=watcher_event)
+            watcher_event_thread.daemon = True
+            watcher_event_thread.start()
+
+            # Create the new file
+            file_open = Open(tree, "directory-watch\\created file")
+            file_open.create(ImpersonationLevel.Impersonation,
+                             FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
+                             FileAttributes.FILE_ATTRIBUTE_NORMAL,
+                             ShareAccess.FILE_SHARE_READ |
+                             ShareAccess.FILE_SHARE_WRITE |
+                             ShareAccess.FILE_SHARE_DELETE,
+                             CreateDisposition.FILE_OPEN_IF,
+                             CreateOptions.FILE_NON_DIRECTORY_FILE)
+            file_open.close()
+
+            watcher_wait_thread.join(timeout=2)
+            watcher_event_thread.join(timeout=2)
+            assert watcher_wait_thread.is_alive() is False
+            assert watcher_event_thread.is_alive() is False
+
+            assert watcher.response_event.is_set()
+            assert len(watcher.result) == 1
+
+            assert watcher.result[0]['file_name'].get_value() == u"created file"
+            assert watcher.result[0]['action'].get_value() == FileAction.FILE_ACTION_ADDED
+
+            open.close()
+        finally:
+            connection.disconnect(True)
+
+    def test_change_notify_no_data(self, smb_real):
+        connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
+        connection.connect()
+        session = Session(connection, smb_real[0], smb_real[1])
+        tree = TreeConnect(session, smb_real[4])
+        open = Open(tree, "directory-watch")
+        try:
+            session.connect()
+            tree.connect()
+
+            open.create(ImpersonationLevel.Impersonation,
+                        DirectoryAccessMask.MAXIMUM_ALLOWED,
+                        FileAttributes.FILE_ATTRIBUTE_DIRECTORY,
+                        ShareAccess.FILE_SHARE_READ |
+                        ShareAccess.FILE_SHARE_WRITE |
+                        ShareAccess.FILE_SHARE_DELETE,
+                        CreateDisposition.FILE_OPEN_IF,
+                        CreateOptions.FILE_DIRECTORY_FILE)
+
+            self._remove_file(tree, "directory-watch\\created file")
+
+            watcher = FileSystemWatcher(open)
+            watcher.start(CompletionFilter.FILE_NOTIFY_CHANGE_FILE_NAME, output_buffer_length=0)
+            assert watcher.result is None
+            assert watcher.response_event.is_set() is False
+
+            # Run the wait in a separate thread so we can create the dir
+            def watcher_wait():
+                watcher.wait()
+            watcher_wait_thread = threading.Thread(target=watcher_wait)
+            watcher_wait_thread.daemon = True
+            watcher_wait_thread.start()
+
+            def watcher_event():
+                watcher.response_event.wait()
+            watcher_event_thread = threading.Thread(target=watcher_event)
+            watcher_event_thread.daemon = True
+            watcher_event_thread.start()
+
+            # Create the new file
+            file_open = Open(tree, "directory-watch\\created file")
+            file_open.create(ImpersonationLevel.Impersonation,
+                             FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
+                             FileAttributes.FILE_ATTRIBUTE_NORMAL,
+                             ShareAccess.FILE_SHARE_READ |
+                             ShareAccess.FILE_SHARE_WRITE |
+                             ShareAccess.FILE_SHARE_DELETE,
+                             CreateDisposition.FILE_OPEN_IF,
+                             CreateOptions.FILE_NON_DIRECTORY_FILE)
+            file_open.close()
+
+            watcher_wait_thread.join(timeout=2)
+            watcher_event_thread.join(timeout=2)
+            assert watcher_wait_thread.is_alive() is False
+            assert watcher_event_thread.is_alive() is False
+
+            assert watcher.response_event.is_set()
+            assert watcher.result == []
+
+            open.close()
+        finally:
+            connection.disconnect(True)
+
+    def test_change_notify_underlying_close(self, smb_real):
+        connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
+        connection.connect()
+        session = Session(connection, smb_real[0], smb_real[1])
+        tree = TreeConnect(session, smb_real[4])
+        open = Open(tree, "directory-watch")
+        try:
+            session.connect()
+            tree.connect()
+
+            open.create(ImpersonationLevel.Impersonation,
+                        DirectoryAccessMask.MAXIMUM_ALLOWED,
+                        FileAttributes.FILE_ATTRIBUTE_DIRECTORY,
+                        ShareAccess.FILE_SHARE_READ |
+                        ShareAccess.FILE_SHARE_WRITE |
+                        ShareAccess.FILE_SHARE_DELETE,
+                        CreateDisposition.FILE_OPEN_IF,
+                        CreateOptions.FILE_DIRECTORY_FILE)
+
+            watcher = FileSystemWatcher(open)
+            watcher.start(CompletionFilter.FILE_NOTIFY_CHANGE_FILE_NAME)
+            assert watcher.result is None
+            assert watcher.response_event.is_set() is False
+
+            open.close()
+
+            expected = "Received unexpected status from the server: (267) STATUS_NOTIFY_CLEANUP"
+            with pytest.raises(SMBResponseException, match=re.escape(expected)):
+                watcher.wait()
+        finally:
+            connection.disconnect(True)
+
+    def test_change_notify_cancel(self, smb_real):
+        connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
+        connection.connect()
+        session = Session(connection, smb_real[0], smb_real[1], require_encryption=False)
+        tree = TreeConnect(session, smb_real[4])
+        open = Open(tree, "directory-watch")
+        try:
+            session.connect()
+            tree.connect()
+
+            open.create(ImpersonationLevel.Impersonation,
+                        DirectoryAccessMask.MAXIMUM_ALLOWED,
+                        FileAttributes.FILE_ATTRIBUTE_DIRECTORY,
+                        ShareAccess.FILE_SHARE_READ |
+                        ShareAccess.FILE_SHARE_WRITE |
+                        ShareAccess.FILE_SHARE_DELETE,
+                        CreateDisposition.FILE_OPEN_IF,
+                        CreateOptions.FILE_DIRECTORY_FILE)
+
+            watcher = FileSystemWatcher(open)
+            watcher.start(CompletionFilter.FILE_NOTIFY_CHANGE_FILE_NAME)
+            assert watcher.result is None
+            assert watcher.response_event.is_set() is False
+
+            # Makes sure that we cancel after the async response has been returned from the server.
+            while watcher._request.async_id is None:
+                pass
+
+            watcher.cancel()
+
+            watcher.wait()
+            assert watcher.cancelled is True
+            assert watcher.result is None
+
+            # Make sure it doesn't cause any weird errors when calling it again
+            watcher.cancel()
+        finally:
+            connection.disconnect(True)
+
+    def test_change_notify_on_a_file(self, smb_real):
+        connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
+        connection.connect()
+        session = Session(connection, smb_real[0], smb_real[1])
+        tree = TreeConnect(session, smb_real[4])
+        open = Open(tree, "file-watch.txt")
+        try:
+            session.connect()
+            tree.connect()
+
+            open.create(ImpersonationLevel.Impersonation,
+                        FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
+                        FileAttributes.FILE_ATTRIBUTE_NORMAL,
+                        ShareAccess.FILE_SHARE_READ |
+                        ShareAccess.FILE_SHARE_WRITE |
+                        ShareAccess.FILE_SHARE_DELETE,
+                        CreateDisposition.FILE_OPEN_IF,
+                        CreateOptions.FILE_NON_DIRECTORY_FILE)
+
+            watcher = FileSystemWatcher(open)
+            watcher.start(CompletionFilter.FILE_NOTIFY_CHANGE_FILE_NAME)
+            assert watcher.result is None
+            assert watcher.response_event.is_set() is False
+
+            expected = "Received unexpected status from the server: (3221225485) STATUS_INVALID_PARAMETER"
+            with pytest.raises(SMBResponseException, match=re.escape(expected)):
+                watcher.wait()
+        finally:
+            connection.disconnect(True)

--- a/tests/test_change_notify.py
+++ b/tests/test_change_notify.py
@@ -332,6 +332,8 @@ class TestChangeNotify(object):
             while watcher._request.async_id is None:
                 pass
 
+            assert watcher.result is None
+
             watcher.cancel()
 
             watcher.wait()
@@ -364,9 +366,6 @@ class TestChangeNotify(object):
 
             watcher = FileSystemWatcher(open)
             watcher.start(CompletionFilter.FILE_NOTIFY_CHANGE_FILE_NAME)
-            assert watcher.result is None
-            assert watcher.response_event.is_set() is False
-
             expected = "Received unexpected status from the server: (3221225485) STATUS_INVALID_PARAMETER"
             with pytest.raises(SMBResponseException, match=re.escape(expected)):
                 watcher.wait()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1168,8 +1168,6 @@ class TestConnection(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM")
     def test_encrypt_ccm(self, monkeypatch):
         def mockurandom(length):
             return b"\xff" * length

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1446,6 +1446,7 @@ class TestOpen(object):
 
             old_last_write_time = open.last_write_time
             old_end_of_file = open.end_of_file
+            time.sleep(2)
             open.write(b"\x01")
             open.close(True)
             assert open.last_write_time != old_last_write_time

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1074,9 +1074,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_dialect_3_0_0(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_0)
@@ -1120,9 +1117,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_dialect_3_0_2(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_2)
@@ -1209,9 +1203,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.name == "nt",
-                        reason="Sharing violation occurs when running with "
-                               "Windows")
     def test_open_root_directory(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_1_1)
@@ -1223,9 +1214,9 @@ class TestOpen(object):
             tree.connect()
 
             dir_open.create(ImpersonationLevel.Impersonation,
-                            DirectoryAccessMask.MAXIMUM_ALLOWED,
+                            DirectoryAccessMask.FILE_LIST_DIRECTORY,
                             FileAttributes.FILE_ATTRIBUTE_DIRECTORY,
-                            0,
+                            ShareAccess.FILE_SHARE_READ,
                             CreateDisposition.FILE_OPEN_IF,
                             CreateOptions.FILE_DIRECTORY_FILE)
             dir_open.close(get_attributes=False)
@@ -1233,9 +1224,6 @@ class TestOpen(object):
             connection.disconnect(True)
 
     # test more file operations here
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_create_directory(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_0)
@@ -1280,9 +1268,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_create_file_create_contexts(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_0)
@@ -1395,9 +1380,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_flush_file(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_2)
@@ -1472,9 +1454,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_read_file_unbuffered(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_2)
@@ -1498,9 +1477,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_read_file_unbuffered_unsupported(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_0)
@@ -1797,8 +1773,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.name == "nt",
-                        reason="flush in compound does't work on windows")
     def test_compounding_open_requests(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect()
@@ -1891,8 +1865,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.name == "nt",
-                        reason="flush in compound does't work on windows")
     def test_compounding_open_requests_unencrypted(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_2_1_0)
@@ -1985,9 +1957,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_close_file_already_closed(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_2)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1653,7 +1653,7 @@ class TestOpen(object):
         connection.connect()
         session = Session(connection, smb_real[0], smb_real[1])
         tree = TreeConnect(session, smb_real[4])
-        open = Open(tree, "directory")
+        open = Open(tree, "directory-query")
         try:
             session.connect()
             tree.connect()
@@ -1667,7 +1667,7 @@ class TestOpen(object):
                         CreateDisposition.FILE_OPEN_IF,
                         CreateOptions.FILE_DIRECTORY_FILE)
 
-            file1 = Open(tree, r"directory\\file1.txt")
+            file1 = Open(tree, r"directory-query\\file1.txt")
             file1.create(ImpersonationLevel.Impersonation,
                          FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
                          FileAttributes.FILE_ATTRIBUTE_NORMAL,
@@ -1676,7 +1676,7 @@ class TestOpen(object):
                          CreateOptions.FILE_NON_DIRECTORY_FILE)
             file1.write(b"\x01\x02\x03\x04", 0)
 
-            file2 = Open(tree, r"directory\\file2.log")
+            file2 = Open(tree, r"directory-query\\file2.log")
             file2.create(ImpersonationLevel.Impersonation,
                          FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
                          FileAttributes.FILE_ATTRIBUTE_NORMAL,
@@ -1804,7 +1804,7 @@ class TestOpen(object):
         connection.connect()
         session = Session(connection, smb_real[0], smb_real[1])
         tree = TreeConnect(session, smb_real[4])
-        open = Open(tree, "directory")
+        open = Open(tree, "directory-compound-open")
         try:
             session.connect()
             tree.connect()
@@ -1818,14 +1818,14 @@ class TestOpen(object):
                         CreateDisposition.FILE_OPEN_IF,
                         CreateOptions.FILE_DIRECTORY_FILE)
 
-            file1 = Open(tree, r"directory\\file1.txt")
+            file1 = Open(tree, r"directory-compound-open\\file1.txt")
             file1.create(ImpersonationLevel.Impersonation,
                          FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
                          FileAttributes.FILE_ATTRIBUTE_NORMAL,
                          ShareAccess.FILE_SHARE_READ,
                          CreateDisposition.FILE_OVERWRITE_IF,
                          CreateOptions.FILE_NON_DIRECTORY_FILE)
-            file2 = Open(tree, r"directory\\file2.log")
+            file2 = Open(tree, r"directory-compound-open\\file2.log")
             file2.create(ImpersonationLevel.Impersonation,
                          FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
                          FileAttributes.FILE_ATTRIBUTE_NORMAL,
@@ -1898,7 +1898,7 @@ class TestOpen(object):
         connection.connect(Dialects.SMB_2_1_0)
         session = Session(connection, smb_real[0], smb_real[1], False)
         tree = TreeConnect(session, smb_real[4])
-        open = Open(tree, "directory")
+        open = Open(tree, "directory-compound-open-plaintext")
         try:
             session.connect()
             tree.connect()
@@ -1912,14 +1912,14 @@ class TestOpen(object):
                         CreateDisposition.FILE_OPEN_IF,
                         CreateOptions.FILE_DIRECTORY_FILE)
 
-            file1 = Open(tree, r"directory\\file1.txt")
+            file1 = Open(tree, r"directory-compound-open-plaintext\\file1.txt")
             file1.create(ImpersonationLevel.Impersonation,
                          FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
                          FileAttributes.FILE_ATTRIBUTE_NORMAL,
                          ShareAccess.FILE_SHARE_READ,
                          CreateDisposition.FILE_OVERWRITE_IF,
                          CreateOptions.FILE_NON_DIRECTORY_FILE)
-            file2 = Open(tree, r"directory\\file2.log")
+            file2 = Open(tree, r"directory-compound-open-plaintext\\file2.log")
             file2.create(ImpersonationLevel.Impersonation,
                          FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
                          FileAttributes.FILE_ATTRIBUTE_NORMAL,
@@ -2087,37 +2087,6 @@ class TestOpen(object):
         finally:
             connection.disconnect(True)
 
-    def test_receive_message_without_request(self, smb_real):
-        connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
-        connection.connect()
-        session = Session(connection, smb_real[0], smb_real[1])
-        tree = TreeConnect(session, smb_real[4])
-        open = Open(tree, "file.txt")
-
-        try:
-            session.connect()
-            tree.connect()
-
-            open.create(ImpersonationLevel.Impersonation,
-                        FilePipePrinterAccessMask.MAXIMUM_ALLOWED,
-                        FileAttributes.FILE_ATTRIBUTE_NORMAL,
-                        0,
-                        CreateDisposition.FILE_OVERWRITE_IF,
-                        CreateOptions.FILE_NON_DIRECTORY_FILE)
-            read_req, unpack_func = open.write(b"\x00", 0, send=False)
-            req = connection.send(read_req, sid=session.session_id,
-                                  tid=tree.tree_connect_id)
-
-            # delete the outstanding request so we throw the exception
-            message_id = req.message['message_id'].get_value()
-            del connection.outstanding_requests[message_id]
-            with pytest.raises(SMBException) as exc:
-                connection.receive(request=req)
-            assert str(exc.value) == "Received response with an unknown " \
-                                     "message ID: %d" % message_id
-        finally:
-            connection.disconnect(True)
-
     def test_receive_with_timeout(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect()
@@ -2142,6 +2111,7 @@ class TestOpen(object):
             # is no response to get
             connection.receive(request=req)
             req.response = None
+            req.response_event.clear()
 
             start_time = time.time()
             with pytest.raises(SMBException) as exc:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -176,9 +176,6 @@ class TestSession(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_dialect_3_0_0(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_0)
@@ -202,9 +199,6 @@ class TestSession(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_dialect_3_0_2(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_2)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,18 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
 import pytest
+import six
 import types
 import uuid
 
-from datetime import datetime
+from datetime import (
+    datetime,
+)
 
 try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
 
-from smbprotocol.connection import Capabilities, Commands, Dialects
-from smbprotocol.structure import Structure, IntField, BytesField, ListField, \
-    UuidField, DateTimeField, StructureField, EnumField, FlagField, \
-    BoolField, _bytes_to_hex, InvalidFieldDefinition
+from smbprotocol.connection import (
+    Capabilities,
+    Commands,
+    Dialects,
+)
+
+from smbprotocol.structure import (
+    _bytes_to_hex,
+    BoolField,
+    BytesField,
+    DateTimeField,
+    EnumField,
+    FlagField,
+    IntField,
+    InvalidFieldDefinition,
+    ListField,
+    Structure,
+    StructureField,
+    TextField,
+    UuidField,
+)
 
 
 def test_bytes_to_hex_pretty_newline():
@@ -276,6 +300,19 @@ class TestIntField(object):
     def test_pack(self):
         field = self.StructureTest()['field']
         expected = b"\xd2\x04\x00\x00"
+        actual = field.pack()
+        assert actual == expected
+
+    def test_pack_signed(self):
+        class UnsignedStructure(Structure):
+            def __init__(self):
+                self.fields = OrderedDict([(
+                    'field', IntField(size=2, unsigned=False, default=-1)
+                )])
+                super(UnsignedStructure, self).__init__()
+
+        field = UnsignedStructure()['field']
+        expected = b"\xff\xff"
         actual = field.pack()
         assert actual == expected
 
@@ -1447,3 +1484,103 @@ class TestBoolField(object):
             field.set_value([])
         assert str(exc.value) == "Cannot parse value for field field of " \
                                  "type list to a bool"
+
+
+class TestTextField(object):
+
+    STRING_VALUE = u"Hello World - café"
+
+    class StructureTest(Structure):
+        def __init__(self):
+            self.fields = OrderedDict([
+                ('field', TextField(encoding='utf-8', default=TestTextField.STRING_VALUE))
+            ])
+            super(TestTextField.StructureTest, self).__init__()
+
+    def test_get_size(self):
+        field = self.StructureTest()['field']
+        expected = 19
+        actual = len(field)
+        assert actual == expected
+
+    def test_to_string(self):
+        field = self.StructureTest()['field']
+        expected = "Hello World - café"  # Need to rely on native string for Python 2 support
+        actual = str(field)
+        assert actual == expected
+        assert field.get_value() == self.STRING_VALUE  # Make's sure the value is a unicode string
+
+    def test_get_value(self):
+        field = self.StructureTest()['field']
+        expected = self.STRING_VALUE
+        actual = field.get_value()
+        assert actual == expected
+
+    def test_pack(self):
+        field = self.StructureTest()['field']
+        expected = b"\x48\x65\x6c\x6c\x6f\x20\x57\x6f" \
+                   b"\x72\x6c\x64\x20\x2d\x20\x63\x61" \
+                   b"\x66\xc3\xa9"
+        actual = field.pack()
+        assert actual == expected
+
+    def test_unpack(self):
+        field = self.StructureTest()['field']
+        field.unpack(b"\x48\x65\x6c\x6c\x6f\x20\x57\x6f"
+                     b"\x72\x6c\x64\x20\x2d\x20\x63\x61"
+                     b"\x66\xc3\xa9")
+        expected = self.STRING_VALUE
+        actual = field.get_value()
+        assert actual == expected
+
+    def test_set_lambda(self):
+        structure = self.StructureTest()
+        field = structure['field']
+        field.name = "field"
+        field.structure = self.StructureTest
+        field.set_value(lambda s: self.STRING_VALUE)
+        expected = self.STRING_VALUE
+        actual = field.get_value()
+        assert isinstance(field.value, types.LambdaType)
+        assert actual == expected
+        assert len(field) == 19
+
+    def test_set_bytes(self):
+        field = self.StructureTest()['field']
+        field.set_value(self.STRING_VALUE.encode('utf-8'))
+        expected = self.STRING_VALUE
+        actual = field.get_value()
+        assert isinstance(field.value, six.text_type)
+        assert actual == expected
+
+    def test_set_none(self):
+        field = self.StructureTest()['field']
+        field.set_value(None)
+        expected = u""
+        actual = field.get_value()
+        assert isinstance(field.value, six.text_type)
+        assert actual == expected
+
+    def test_set_invalid(self):
+        field = self.StructureTest()['field']
+        field.name = "field"
+        with pytest.raises(TypeError) as exc:
+            field.set_value([])
+        assert str(exc.value) == "Cannot parse value for field field of " \
+                                 "type list to a text string"
+
+    def test_set_with_different_encoding(self):
+        structure = self.StructureTest()
+        field = structure['field']
+        field.encoding = 'utf-16-le'
+        field.set_value(self.STRING_VALUE)
+
+        assert len(field) == 36
+        actual = field.get_value()
+        assert actual == self.STRING_VALUE
+        actual_pack = field.pack()
+        assert actual_pack == self.STRING_VALUE.encode('utf-16-le')
+
+        field.set_value("")
+        field.unpack(actual_pack)
+        assert field.get_value() == self.STRING_VALUE

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from six import PY3
+
+from smbprotocol._text import (
+    to_bytes,
+    to_native,
+    to_text,
+)
+
+
+def test_text_to_bytes_default():
+    expected = b"\x61\x62\x63"
+    actual = to_bytes(u"abc")
+    assert actual == expected
+
+
+def test_text_to_bytes_diff_encoding():
+    expected = b"\x61\x00\x62\x00\x63\x00"
+    actual = to_bytes(u"abc", encoding='utf-16-le')
+    assert actual == expected
+
+
+def test_bytes_to_bytes():
+    expected = b"\x01\x02\x03\x04"
+    actual = to_bytes(b"\x01\x02\x03\x04")
+    assert actual == expected
+
+
+def test_native_to_bytes():
+    # Python 3 the default string type is unicode so the expected value will
+    # be "abc" in UTF-16 form while Python 2 "abc" is the bytes representation
+    # already
+    if PY3:
+        expected = b"\x61\x00\x62\x00\x63\x00"
+    else:
+        expected = b"\x61\x62\x63"
+    actual = to_bytes("abc", encoding='utf-16-le')
+    assert actual == expected
+
+
+def test_text_to_text():
+    expected = u"abc"
+    actual = to_text(u"abc")
+    assert actual == expected
+
+
+def test_byte_to_text():
+    expected = u"abc"
+    actual = to_text(b"\x61\x62\x63")
+    assert actual == expected
+
+
+def test_byte_to_text_diff_encoding():
+    expected = u"abc"
+    actual = to_text(b"\x61\x00\x62\x00\x63\x00", encoding='utf-16-le')
+    assert actual == expected
+
+
+def test_native_to_unicode():
+    if PY3:
+        expected = u"a\x00b\x00c\x00"
+    else:
+        expected = u"abc"
+    actual = to_text("a\x00b\x00c\x00", encoding='utf-16-le')
+    assert actual == expected
+
+
+def test_to_native():
+    if PY3:
+        assert str(to_native).startswith("<function to_text")
+    else:
+        assert to_native.func_name == "to_bytes"

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,6 +1,4 @@
-import errno
 import re
-import socket
 
 import pytest
 
@@ -37,29 +35,15 @@ class TestDirectTcpPacket(object):
 class TestTcp(object):
 
     def test_normal_fail_message_too_big(self):
-        tcp = Tcp("0.0.0.0", 0)
+        tcp = Tcp("0.0.0.0", 0, None)
+        tcp._sock = True
         with pytest.raises(ValueError) as exc:
             tcp.send(b"\x00" * 16777216)
         assert str(exc.value) == "Data to be sent over Direct TCP size " \
                                  "16777216 exceeds the max length allowed " \
                                  "16777215"
 
-    def test_send_fail_non_blocking(self):
-        # ensure it doesn't loop when a non blocking error is raised
-        tcp = Tcp("0.0.0.0", 0)
-        tcp._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        with pytest.raises(socket.error) as err:
-            tcp.send(b"\x01\x02\x03\x04")
-
-    def test_recv_fail_non_blocking(self):
-        # ensure it doesn't loop when a non blocking error is raised
-        tcp = Tcp("0.0.0.0", 0)
-        tcp._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        with pytest.raises(socket.error) as err:
-            tcp._recv(10)
-        assert err.value.errno == errno.ENOTCONN
-
     def test_invalid_host(self):
-        tcp = Tcp("fake-host", 445)
+        tcp = Tcp("fake-host", 445, None)
         with pytest.raises(ValueError, match=re.escape("Failed to connect to 'fake-host:445': ")):
-            tcp.connect()
+            tcp.send(b"")

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -140,9 +140,6 @@ class TestTreeConnect(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_dialect_3_0_0(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_0)
@@ -159,9 +156,6 @@ class TestTreeConnect(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_dialect_3_0_2(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_2)
@@ -225,9 +219,6 @@ class TestTreeConnect(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_secure_negotiation_verification_failed(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_2)
@@ -243,9 +234,6 @@ class TestTreeConnect(object):
         finally:
             connection.disconnect(True)
 
-    @pytest.mark.skipif(os.environ.get("TRAVIS_PYTHON_VERSION", "") == '2.6',
-                        reason="Travis-CI Python 2.6 does not support AES CCM "
-                               "required for Dialect 3.0.0 and 3.0.2 enc")
     def test_secure_ignore_negotiation_verification_failed(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect(Dialects.SMB_3_0_2)


### PR DESCRIPTION
Changed the listener and message processing side of smbprotocol to run in a thread in the background. This is designed to simplify the message processing and to better handle asynchronous messages sent to and from the server.

Also adds a `FileSystemWatcher` that can be used to detect when a change has occurred in a directory on a remote server. Also introduced a way to cancel background running requests.