### PR TITLE
Add various shutil methods

### DIFF
--- a/smbclient/__init__.py
+++ b/smbclient/__init__.py
@@ -44,6 +44,7 @@ from smbclient._os import (
     SMBStatResult,
     XATTR_CREATE,
     XATTR_REPLACE,
+    copyfile_server_side
 )
 
 try:

--- a/smbclient/__init__.py
+++ b/smbclient/__init__.py
@@ -44,7 +44,7 @@ from smbclient._os import (
     SMBStatResult,
     XATTR_CREATE,
     XATTR_REPLACE,
-    copyfile_server_side
+    copyfile
 )
 
 try:

--- a/smbclient/shutil.py
+++ b/smbclient/shutil.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+from __future__ import unicode_literals
+import errno
+
+from ntpath import join, basename, normcase, abspath, normpath, splitdrive
+
+import sys
+import stat as py_stat
+from os import error as os_error
+
+from smbclient._io import ioctl_request, SMBFileTransaction, SMBRawIO
+from smbclient._os import remove, rmdir, listdir, lstat, stat, utime, open_file, makedirs, readlink, symlink
+from smbclient.path import islink, isdir
+from smbprotocol.exceptions import SMBOSError
+from smbprotocol.ioctl import SMB2SrvCopyChunk, IOCTLFlags, SMB2SrvCopyChunkResponse, CtlCode, SMB2SrvCopyChunkCopy, \
+    SMB2SrvRequestResumeKey
+from smbprotocol.open import FilePipePrinterAccessMask, CreateOptions, ShareAccess
+
+CHUNK_SIZE = 1 * 1024 * 1024  # maximum chunksize allowed by smb
+
+
+class Error(EnvironmentError):
+    pass
+
+
+class SpecialFileError(EnvironmentError):
+    """Raised when trying to do a kind of operation (e.g. copying) which is
+    not supported on a special file (e.g. a named pipe)"""
+
+
+def rmtree(path, ignore_errors=False, onerror=None, **kwargs):
+    """Recursively delete a directory tree.
+
+    If ignore_errors is set, errors are ignored; otherwise, if onerror
+    is set, it is called to handle the error with arguments (func,
+    path, exc_info) where func is smbclient.listdir, smbclient.remove,
+    or smbclient.rmdir;
+    path is the argument to that function that caused it to fail; and
+    exc_info is a tuple returned by sys.exc_info().  If ignore_errors
+    is false and onerror is None, an exception is raised.
+
+    :param path: The path to remove.
+    :param ignore_errors: The ignore errors flag.
+    :param onerror: The callback executed on errors
+    :param kwargs: Common arguments used to build the SMB Session.
+    :return: True if path is a dir or points to a dir.
+    """
+    if ignore_errors:
+        def onerror(*args):
+            pass
+    elif onerror is None:
+        def onerror(*args):
+            raise
+    try:
+        if islink(path, **kwargs):
+            # symlinks to directories are forbidden, see bug #1669
+            raise OSError("Cannot call rmtree on a symbolic link")
+    except OSError:
+        onerror(islink, path, sys.exc_info())
+        # can't continue even if onerror hook returns
+        return
+
+    names = []
+    try:
+        names = listdir(path, **kwargs)
+    except os_error:
+        onerror(listdir, path, sys.exc_info())
+    for name in names:
+        fullname = join(path, name)
+        try:
+            mode = lstat(fullname, **kwargs).st_mode
+        except os_error:
+            mode = 0
+        if py_stat.S_ISDIR(mode):
+            rmtree(fullname, ignore_errors, onerror, **kwargs)
+        else:
+            try:
+                remove(fullname, **kwargs)
+            except os_error:
+                onerror(remove, fullname, sys.exc_info())
+    try:
+        rmdir(path, **kwargs)
+    except os_error:
+        onerror(rmdir, path, sys.exc_info())
+
+
+def copy2(src, dst, server_side_copy=False, **kwargs):
+    """Copy data and metadata. Return the file's destination.
+
+    Metadata is copied with copystat(). Please see the copystat function
+    for more information.
+
+    The destination may be a directory.
+
+    """
+    if isdir(dst, **kwargs):
+        dst = join(dst, basename(src))
+    if server_side_copy:
+        copyfile_server_side(src, dst, **kwargs)
+    else:
+        copyfile(src, dst, **kwargs)
+    copystat(src, dst, **kwargs)
+
+
+def copystat(src, dst, **kwargs):
+    """Copy file metadata
+
+    Copy the permission bits, last access time, last modification time, and
+    flags from `src` to `dst`. The file contents, owner, and group are
+    unaffected. `src` and `dst` are path names given as strings.
+    """
+    st = stat(src, **kwargs)
+    utime(dst, ns=(st.st_atime_ns, st.st_mtime_ns), **kwargs)
+
+    # TODO: in principle, we can copy the readonly flag via chmod
+    # mode = py_stat.S_IMODE(st.st_mode)
+    # if hasattr(os, 'chmod'):
+    #     os.chmod(dst, mode)
+
+
+def copyfile(src, dst, **kwargs):
+    """Copy data from src to dst"""
+    if _samefile(src, dst):
+        raise Error("`%s` and `%s` are the same file" % (src, dst))
+
+    for fn in [src, dst]:
+        try:
+            st = stat(fn, **kwargs)
+        except OSError:
+            # File most likely does not exist
+            pass
+        else:
+            # XXX What about other special files? (sockets, devices...)
+            if py_stat.S_ISFIFO(st.st_mode):
+                raise SpecialFileError("`%s` is a named pipe" % fn)
+
+    with open_file(src, 'rb', **kwargs) as fsrc:
+        with open_file(dst, 'wb', **kwargs) as fdst:
+            copyfileobj(fsrc, fdst)
+
+
+def copytree(src, dst, symlinks=False, ignore=None, server_side_copy=False, **kwargs):
+    """Recursively copy a directory tree using copy2().
+
+    The destination directory must not already exist.
+    If exception(s) occur, an Error is raised with a list of reasons.
+
+    If the optional symlinks flag is true, symbolic links in the
+    source tree result in symbolic links in the destination tree; if
+    it is false, the contents of the files pointed to by symbolic
+    links are copied.
+
+    The optional ignore argument is a callable. If given, it
+    is called with the `src` parameter, which is the directory
+    being visited by copytree(), and `names` which is the list of
+    `src` contents, as returned by os.listdir():
+
+        callable(src, names) -> ignored_names
+
+    Since copytree() is called recursively, the callable will be
+    called once for each directory that is copied. It returns a
+    list of names relative to the `src` directory that should
+    not be copied.
+
+    XXX Consider this example code rather than the ultimate tool.
+
+    """
+    names = listdir(src, **kwargs)
+    if ignore is not None:
+        ignored_names = ignore(src, names)
+    else:
+        ignored_names = set()
+
+    makedirs(dst, **kwargs)
+    errors = []
+    for name in names:
+        if name in ignored_names:
+            continue
+        srcname = join(src, name)
+        dstname = join(dst, name)
+        try:
+            if symlinks and islink(srcname, **kwargs):
+                linkto = readlink(srcname, **kwargs)
+                symlink(linkto, dstname, **kwargs)
+            elif isdir(srcname, **kwargs):
+                copytree(srcname, dstname, symlinks, ignore, **kwargs)
+            else:
+                # Will raise a SpecialFileError for unsupported file types
+                copy2(srcname, dstname, server_side_copy=server_side_copy, **kwargs)
+        # catch the Error from the recursive copytree so that we can
+        # continue with other files
+        except Error as err:
+            errors.extend(err.args[0])
+        except EnvironmentError as why:
+            errors.append((srcname, dstname, str(why)))
+    try:
+        copystat(src, dst)
+    except OSError as why:
+        if WindowsError is not None and isinstance(why, WindowsError):
+            # Copying file access times may fail on Windows
+            pass
+        else:
+            errors.append((src, dst, str(why)))
+    if errors:
+        raise Error(errors)
+
+
+def copyfile_server_side(src, dst, **kwargs):
+    """
+    Server side copy of a file
+
+    :param src: The source file.
+    :param dst: The target file.
+    :param kwargs: Common SMB Session arguments for smbclient.
+    """
+
+    norm_dst = normpath(dst)
+    norm_src = normpath(src)
+
+    src_drive = splitdrive(norm_src)[0]
+    dst_drive = splitdrive(norm_dst)[0]
+    if src_drive.lower() != dst_drive.lower():
+        raise ValueError(
+            "Server side copy can only occur on the same drive, '%s' must be the same as the dst root '%s'" % (
+                src_drive, dst_drive))
+
+    try:
+        stat(norm_dst, **kwargs)
+    except SMBOSError as err:
+        if err.errno != errno.ENOENT:
+            raise
+    else:
+        raise ValueError("Target %s already exists" % norm_dst)
+
+    with SMBRawIO(norm_src, mode='r', desired_access=FilePipePrinterAccessMask.GENERIC_READ,
+                  create_options=(CreateOptions.FILE_NON_DIRECTORY_FILE), share_access='r',
+                  **kwargs) as raw_src:
+
+        with SMBFileTransaction(raw_src) as transaction_src:
+            ioctl_request(transaction_src, CtlCode.FSCTL_SRV_REQUEST_RESUME_KEY,
+                          flags=IOCTLFlags.SMB2_0_IOCTL_IS_FSCTL,
+                          output_size=32)
+
+        val_resp = SMB2SrvRequestResumeKey()
+        val_resp.unpack(transaction_src.results[0])
+
+        chunks = _get_srv_copy_chunks(transaction_src)
+
+        with SMBRawIO(norm_dst, mode='x', desired_access=FilePipePrinterAccessMask.GENERIC_WRITE,
+                      share_access='r',
+                      create_options=(CreateOptions.FILE_NON_DIRECTORY_FILE), **kwargs) as raw_dst:
+
+            with SMBFileTransaction(raw_dst) as transaction_dst:
+                for batch in _batches(chunks, 16):
+                    copychunkcopy_struct = SMB2SrvCopyChunkCopy()
+                    copychunkcopy_struct['source_key'] = val_resp['resume_key'].get_value()
+                    copychunkcopy_struct['chunks'] = batch
+
+                    ioctl_request(transaction_dst, CtlCode.FSCTL_SRV_COPYCHUNK_WRITE,
+                                  flags=IOCTLFlags.SMB2_0_IOCTL_IS_FSCTL,
+                                  output_size=32, buffer=copychunkcopy_struct)
+
+            for result in transaction_dst.results:
+                copychunk_response = SMB2SrvCopyChunkResponse()
+                copychunk_response.unpack(result)
+                if copychunk_response['chunks_written'].get_value() < 1:
+                    raise SMBOSError('Could not copy chunks in server side copy', filename=norm_dst)
+
+
+def _get_srv_copy_chunks(transaction):
+    chunks = []
+    offset = 0
+
+    while offset < transaction.raw.fd.end_of_file:
+        copychunk_struct = SMB2SrvCopyChunk()
+        copychunk_struct['source_offset'] = offset
+        copychunk_struct['target_offset'] = offset
+        if offset + CHUNK_SIZE < transaction.raw.fd.end_of_file:
+            copychunk_struct['length'] = CHUNK_SIZE
+        else:
+            copychunk_struct['length'] = transaction.raw.fd.end_of_file - offset
+
+        chunks.append(copychunk_struct)
+        offset += CHUNK_SIZE
+
+    return chunks
+
+
+def _batches(lst, n):
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
+
+
+def _samefile(src, dst):
+    return normcase(abspath(src)) == normcase(abspath(dst))
+
+
+def copyfileobj(fsrc, fdst, length=16 * 1024):
+    """copy data from file-like object fsrc to file-like object fdst"""
+    while 1:
+        buf = fsrc.read(length)
+        if not buf:
+            break
+        fdst.write(buf)

--- a/smbclient/shutil.py
+++ b/smbclient/shutil.py
@@ -6,18 +6,13 @@ import sys
 import os.path
 from os import error as os_error
 
-from smbclient._os import remove, rmdir, listdir, stat, makedirs, readlink, symlink, scandir, copyfile_server_side
+from smbclient._os import remove, rmdir, listdir, stat, makedirs, readlink, symlink, scandir, copyfile
 from smbclient.path import islink, isdir
 from smbprotocol.exceptions import SMBOSError
 
 
 class Error(EnvironmentError):
     pass
-
-
-class SpecialFileError(EnvironmentError):
-    """Raised when trying to do a kind of operation (e.g. copying) which is
-    not supported on a special file (e.g. a named pipe)"""
 
 
 def rmtree(path, ignore_errors=False, onerror=None, **kwargs):
@@ -79,11 +74,14 @@ def copy(src, dst, **kwargs):
     if isdir(dst, **kwargs):
         dst = join(dst, basename(src))
 
-    copyfile_server_side(src, dst, **kwargs)
+    copyfile(src, dst, **kwargs)
 
 
-def copytree_copy(src, dst, symlinks=False, ignore=None, **kwargs):
+def copytree(src, dst, symlinks=False, ignore=None, **kwargs):
     """Recursively copy a directory tree using copy().
+
+    Note: later on, copytree might use copy2 similar to the shutil
+          counterpart.
 
     The destination directory must not already exist.
     If exception(s) occur, an Error is raised with a list of reasons.
@@ -128,7 +126,7 @@ def copytree_copy(src, dst, symlinks=False, ignore=None, **kwargs):
                 linkto = readlink(srcname, **kwargs)
                 symlink(linkto, dstname, **kwargs)
             elif isdir(srcname, **kwargs):
-                copytree_copy(srcname, dstname, symlinks, ignore, **kwargs)
+                copytree(srcname, dstname, symlinks, ignore, **kwargs)
             else:
                 # Will raise a SpecialFileError for unsupported file types
                 copy(srcname, dstname, **kwargs)

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -1267,8 +1267,8 @@ def test_symlink_file_missing_src(smb_share):
     assert smbclient.listdir(smb_share) == ['link.txt']
     actual = smbclient.lstat(dst_filename)
     assert stat.S_ISLNK(actual.st_mode)
-    assert actual.st_file_attributes == \
-           FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE
+    assert actual.st_file_attributes == (
+        FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE)
 
 
 @pytest.mark.skipif(os.name != "nt" and not os.environ.get('SMB_FORCE', False),
@@ -1288,8 +1288,8 @@ def test_symlink_file_existing_src(smb_share):
 
     actual = smbclient.lstat(dst_filename)
     assert stat.S_ISLNK(actual.st_mode)
-    assert actual.st_file_attributes == \
-           FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE
+    assert actual.st_file_attributes == (
+        FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE)
 
 
 @pytest.mark.skipif(os.name != "nt" and not os.environ.get('SMB_FORCE', False),
@@ -1303,8 +1303,8 @@ def test_symlink_dir_missing_src(smb_share):
     assert smbclient.listdir(smb_share) == ['link']
     actual = smbclient.lstat(dst_dirname)
     assert stat.S_ISLNK(actual.st_mode)
-    assert actual.st_file_attributes == \
-           FileAttributes.FILE_ATTRIBUTE_DIRECTORY | FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT
+    assert actual.st_file_attributes == (
+        FileAttributes.FILE_ATTRIBUTE_DIRECTORY | FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT)
 
 
 @pytest.mark.skipif(os.name != "nt" and not os.environ.get('SMB_FORCE', False),
@@ -1322,8 +1322,8 @@ def test_symlink_dir_existing_src(smb_share):
     assert 'dir' in actual_dirs
     actual = smbclient.lstat(dst_dirname)
     assert stat.S_ISLNK(actual.st_mode)
-    assert actual.st_file_attributes == \
-           FileAttributes.FILE_ATTRIBUTE_DIRECTORY | FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT
+    assert actual.st_file_attributes == (
+        FileAttributes.FILE_ATTRIBUTE_DIRECTORY | FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT)
 
 
 @pytest.mark.skipif(os.name != "nt" and not os.environ.get('SMB_FORCE', False),
@@ -1345,8 +1345,8 @@ def test_symlink_relative_src(smb_share):
 
     actual = smbclient.lstat(dst_filename)
     assert stat.S_ISLNK(actual.st_mode)
-    assert actual.st_file_attributes == \
-           FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE
+    assert actual.st_file_attributes == (
+        FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE)
 
 
 def test_symlink_fail_not_absolute_dst(smb_share):

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -16,8 +16,7 @@ import stat
 from smbclient._os import (
     SMBDirectoryIO,
     SMBDirEntry,
-    SMBFileIO,
-)
+    SMBFileIO)
 
 from smbprotocol.exceptions import (
     SMBAuthenticationError,
@@ -1269,7 +1268,7 @@ def test_symlink_file_missing_src(smb_share):
     actual = smbclient.lstat(dst_filename)
     assert stat.S_ISLNK(actual.st_mode)
     assert actual.st_file_attributes == \
-        FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE
+           FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE
 
 
 @pytest.mark.skipif(os.name != "nt" and not os.environ.get('SMB_FORCE', False),
@@ -1290,7 +1289,7 @@ def test_symlink_file_existing_src(smb_share):
     actual = smbclient.lstat(dst_filename)
     assert stat.S_ISLNK(actual.st_mode)
     assert actual.st_file_attributes == \
-        FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE
+           FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE
 
 
 @pytest.mark.skipif(os.name != "nt" and not os.environ.get('SMB_FORCE', False),
@@ -1305,7 +1304,7 @@ def test_symlink_dir_missing_src(smb_share):
     actual = smbclient.lstat(dst_dirname)
     assert stat.S_ISLNK(actual.st_mode)
     assert actual.st_file_attributes == \
-        FileAttributes.FILE_ATTRIBUTE_DIRECTORY | FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT
+           FileAttributes.FILE_ATTRIBUTE_DIRECTORY | FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT
 
 
 @pytest.mark.skipif(os.name != "nt" and not os.environ.get('SMB_FORCE', False),
@@ -1324,7 +1323,7 @@ def test_symlink_dir_existing_src(smb_share):
     actual = smbclient.lstat(dst_dirname)
     assert stat.S_ISLNK(actual.st_mode)
     assert actual.st_file_attributes == \
-        FileAttributes.FILE_ATTRIBUTE_DIRECTORY | FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT
+           FileAttributes.FILE_ATTRIBUTE_DIRECTORY | FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT
 
 
 @pytest.mark.skipif(os.name != "nt" and not os.environ.get('SMB_FORCE', False),
@@ -1347,7 +1346,7 @@ def test_symlink_relative_src(smb_share):
     actual = smbclient.lstat(dst_filename)
     assert stat.S_ISLNK(actual.st_mode)
     assert actual.st_file_attributes == \
-        FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE
+           FileAttributes.FILE_ATTRIBUTE_REPARSE_POINT | FileAttributes.FILE_ATTRIBUTE_ARCHIVE
 
 
 def test_symlink_fail_not_absolute_dst(smb_share):
@@ -1746,3 +1745,24 @@ def test_xattr_dont_follow(smb_share):
 
     smbclient.removexattr(dst_filename, b"KEY", follow_symlinks=False)
     assert smbclient.listxattr(dst_filename, follow_symlinks=False) == []
+
+
+def test_copy_across_paths_raises(smb_share):
+    expected = 'Server side copy can only occur on the same drive'
+    with pytest.raises(ValueError, match=re.escape(expected)):
+        smbclient.copyfile_server_side("//127.0.0.1/filer1/file1", "//host/filer2/file2")
+
+
+def test_server_side_copy_multiple_chunks(smb_share):
+    smbclient.mkdir("%s\\dir2" % smb_share)
+    with smbclient.open_file("%s\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content" * 1024)
+
+    smbclient._os.CHUNK_SIZE = 1024
+
+    smbclient.copyfile_server_side("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share)
+
+    src_stat = smbclient.stat("%s\\file1" % smb_share)
+    dst_stat = smbclient.stat("%s\\dir2\\file1" % smb_share)
+
+    assert src_stat.st_size == dst_stat.st_size

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -1750,7 +1750,7 @@ def test_xattr_dont_follow(smb_share):
 def test_copy_across_paths_raises(smb_share):
     expected = 'Server side copy can only occur on the same drive'
     with pytest.raises(ValueError, match=re.escape(expected)):
-        smbclient.copyfile_server_side("//127.0.0.1/filer1/file1", "//host/filer2/file2")
+        smbclient.copyfile("//127.0.0.1/filer1/file1", "//host/filer2/file2")
 
 
 def test_server_side_copy_multiple_chunks(smb_share):
@@ -1760,7 +1760,7 @@ def test_server_side_copy_multiple_chunks(smb_share):
 
     smbclient._os.CHUNK_SIZE = 1024
 
-    smbclient.copyfile_server_side("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share)
+    smbclient.copyfile("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share)
 
     src_stat = smbclient.stat("%s\\file1" % smb_share)
     dst_stat = smbclient.stat("%s\\dir2\\file1" % smb_share)

--- a/tests/test_smbclient_shutil.py
+++ b/tests/test_smbclient_shutil.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from __future__ import division
+
+import sys
+
+import pytest
+import re
+from time import sleep
+
+import smbclient
+from smbclient import open_file, mkdir, stat
+from smbclient.path import exists, isdir
+from smbclient.shutil import rmtree, copy2, copytree, Error, copyfile_server_side, copyfile
+
+
+def test_rmtree(smb_share):
+    mkdir("%s\\dir2" % smb_share)
+    mkdir("%s\\dir2\\dir3" % smb_share)
+
+    with open_file("%s\\dir2\\dir3\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
+    with open_file("%s\\dir2\\file2" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
+    assert exists("%s\\dir2" % smb_share) is True
+
+    rmtree("%s\\dir2" % smb_share)
+
+    assert exists("%s\\dir2" % smb_share) is False
+
+
+def test_rmtree_non_existing(smb_share):
+    expected = "[NtStatus 0xc0000034] No such file or directory: "
+    with pytest.raises(OSError, match=re.escape(expected)):
+        rmtree("%s\\dir2" % smb_share)
+
+
+def test_rmtree_non_existing_with_error_callback(smb_share):
+    callback_args = []
+
+    def callback(*args):
+        callback_args.append(args)
+
+    assert not callback_args
+
+    rmtree("%s\\dir2" % smb_share, onerror=callback)
+
+    assert callback_args
+
+
+def test_rmtree_non_existing_ignore_errors(smb_share):
+    rmtree("%s\\dir2" % smb_share, ignore_errors=True)
+
+
+def test_copy2(smb_share):
+    mkdir("%s\\dir2" % smb_share)
+    with open_file("%s\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
+    sleep(0.1)
+    copy2("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share)
+
+    src_stat = stat("%s\\file1" % smb_share)
+    dst_stat = stat("%s\\dir2\\file1" % smb_share)
+    assert src_stat.st_atime == dst_stat.st_atime
+    assert src_stat.st_mtime == dst_stat.st_mtime
+    assert src_stat.st_size == dst_stat.st_size
+
+
+def test_copy2_raises_when_source_and_target_identical(smb_share):
+    mkdir("%s\\dir2" % smb_share)
+    with open_file("%s\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
+    sleep(0.1)
+    if (sys.version_info > (3, 0)):
+        expected = 'are the same file'
+        context = pytest.raises(Error, match=re.escape(expected))
+    else:
+        context = pytest.raises(Error)
+
+    with context:
+        copy2("%s\\file1" % smb_share, "%s\\file1" % smb_share)
+
+
+def test_copy2_with_dir_as_target(smb_share):
+    mkdir("%s\\dir2" % smb_share)
+    with open_file("%s\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
+    sleep(0.1)
+    copy2("%s\\file1" % smb_share, "%s\\dir2" % smb_share)
+
+    src_stat = stat("%s\\file1" % smb_share)
+    dst_stat = stat("%s\\dir2\\file1" % smb_share)
+    assert src_stat.st_atime == dst_stat.st_atime
+    assert src_stat.st_mtime == dst_stat.st_mtime
+    assert src_stat.st_size == dst_stat.st_size
+
+
+def test_copytree(smb_share):
+    mkdir("%s\\dir2" % smb_share)
+    mkdir("%s\\dir2\\dir3" % smb_share)
+
+    with open_file("%s\\dir2\\dir3\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
+    with open_file("%s\\dir2\\file2" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
+    sleep(0.01)
+    copytree("%s\\dir2" % smb_share, "%s\\dir4" % smb_share)
+
+    src_stat = stat("%s\\dir2\\dir3\\file1" % smb_share)
+    dst_stat = stat("%s\\dir4\\dir3\\file1" % smb_share)
+    assert src_stat.st_atime == dst_stat.st_atime
+    assert src_stat.st_mtime == dst_stat.st_mtime
+    assert src_stat.st_size == dst_stat.st_size
+
+
+def test_copytree_with_skip(smb_share):
+    mkdir("%s\\dir2" % smb_share)
+    mkdir("%s\\dir2\\dir3" % smb_share)
+
+    with open_file("%s\\dir2\\dir3\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
+    with open_file("%s\\dir2\\file2" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
+    def ignore(src, names):
+        return [name for name in names if name == "file2"]
+
+    sleep(0.01)
+    copytree("%s\\dir2" % smb_share, "%s\\dir4" % smb_share, ignore=ignore)
+
+    assert exists("%s\\dir4\\dir3\\file1" % smb_share) is True
+    assert exists("%s\\dir4\\file2" % smb_share) is False
+
+
+def test_copyfile_with_same_file(smb_share):
+    if (sys.version_info > (3, 0)):
+        expected = 'are the same file'
+        context = pytest.raises(Error, match=re.escape(expected))
+    else:
+        context = pytest.raises(Error)
+
+    with context:
+        copyfile("%s\\file1" % smb_share, "%s\\file1" % smb_share)
+
+
+def test_server_side_copy(smb_share):
+    mkdir("%s\\dir2" % smb_share)
+    with open_file("%s\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content" * 1024)
+
+    sleep(0.1)
+    copy2("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share, server_side_copy=True)
+
+    src_stat = stat("%s\\file1" % smb_share)
+    dst_stat = stat("%s\\dir2\\file1" % smb_share)
+    assert src_stat.st_atime == dst_stat.st_atime
+    assert src_stat.st_mtime == dst_stat.st_mtime
+    assert src_stat.st_size == dst_stat.st_size
+
+
+def test_server_side_copy_across_paths_raises():
+    expected = 'Server side copy can only occur on the same drive'
+    with pytest.raises(ValueError, match=re.escape(expected)):
+        copyfile_server_side("//host/filer1/file1", "//host/filer2/file2")
+
+
+def test_server_side_copy_target_exists(smb_share):
+    with open_file("%s\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content" * 1024)
+    with open_file("%s\\file2" % smb_share, mode='w') as fd:
+        fd.write(u"content" * 1024)
+
+    if (sys.version_info > (3, 0)):
+        expected = 'already exists'
+        context = pytest.raises(ValueError, match=re.escape(expected))
+    else:
+        context = pytest.raises(ValueError)
+
+    with context:
+        copyfile_server_side("%s\\file1" % smb_share, "%s\\file2" % smb_share)
+
+
+def test_server_side_copy_multiple_chunks(smb_share):
+    mkdir("%s\\dir2" % smb_share)
+    with open_file("%s\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content" * 1024)
+
+    smbclient.shutil.CHUNK_SIZE = 1024
+
+    sleep(0.1)
+    copy2("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share, server_side_copy=True)
+
+    src_stat = stat("%s\\file1" % smb_share)
+    dst_stat = stat("%s\\dir2\\file1" % smb_share)
+    assert src_stat.st_atime == dst_stat.st_atime
+    assert src_stat.st_mtime == dst_stat.st_mtime
+    assert src_stat.st_size == dst_stat.st_size

--- a/tests/test_smbclient_shutil.py
+++ b/tests/test_smbclient_shutil.py
@@ -9,11 +9,10 @@ import sys
 
 import pytest
 import re
-from time import sleep
 
 from smbclient import open_file, mkdir, stat, symlink
 from smbclient.path import exists
-from smbclient.shutil import rmtree, copy, copytree_copy
+from smbclient.shutil import rmtree, copy, copytree
 
 
 def test_rmtree(smb_share):
@@ -64,7 +63,6 @@ def test_copy(smb_share):
     with open_file("%s\\file1" % smb_share, mode='w') as fd:
         fd.write(u"content")
 
-    sleep(0.1)
     copy("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share)
 
     src_stat = stat("%s\\file1" % smb_share)
@@ -78,7 +76,6 @@ def test_copy_raises_when_source_and_target_identical(smb_share):
     with open_file("%s\\file1" % smb_share, mode='w') as fd:
         fd.write(u"content")
 
-    sleep(0.1)
     if (sys.version_info > (3, 0)):
         expected = 'are the same file'
         context = pytest.raises(ValueError, match=re.escape(expected))
@@ -94,7 +91,6 @@ def test_copy_with_dir_as_target(smb_share):
     with open_file("%s\\file1" % smb_share, mode='w') as fd:
         fd.write(u"content")
 
-    sleep(0.1)
     copy("%s\\file1" % smb_share, "%s\\dir2" % smb_share)
 
     src_stat = stat("%s\\file1" % smb_share)
@@ -113,8 +109,7 @@ def test_copytree(smb_share):
     with open_file("%s\\dir2\\file2" % smb_share, mode='w') as fd:
         fd.write(u"content")
 
-    sleep(0.01)
-    copytree_copy("%s\\dir2" % smb_share, "%s\\dir4" % smb_share)
+    copytree("%s\\dir2" % smb_share, "%s\\dir4" % smb_share)
 
     src_stat = stat("%s\\dir2\\dir3\\file1" % smb_share)
     dst_stat = stat("%s\\dir4\\dir3\\file1" % smb_share)
@@ -135,8 +130,7 @@ def test_copytree_with_skip(smb_share):
     def ignore(src, names):
         return [name for name in names if name == "file2"]
 
-    sleep(0.01)
-    copytree_copy("%s\\dir2" % smb_share, "%s\\dir4" % smb_share, ignore=ignore)
+    copytree("%s\\dir2" % smb_share, "%s\\dir4" % smb_share, ignore=ignore)
 
     assert exists("%s\\dir4\\dir3\\file1" % smb_share) is True
     assert exists("%s\\dir4\\file2" % smb_share) is False

--- a/tests/test_smbclient_shutil.py
+++ b/tests/test_smbclient_shutil.py
@@ -4,6 +4,7 @@
 
 from __future__ import division
 
+import os
 import sys
 
 import pytest
@@ -11,9 +12,9 @@ import re
 from time import sleep
 
 import smbclient
-from smbclient import open_file, mkdir, stat
-from smbclient.path import exists, isdir
-from smbclient.shutil import rmtree, copy2, copytree, Error, copyfile_server_side, copyfile
+from smbclient import open_file, mkdir, stat, symlink
+from smbclient.path import exists
+from smbclient.shutil import rmtree, copy, copytree_copy, _copyfile_server_side, copyfile
 
 
 def test_rmtree(smb_share):
@@ -25,6 +26,9 @@ def test_rmtree(smb_share):
 
     with open_file("%s\\dir2\\file2" % smb_share, mode='w') as fd:
         fd.write(u"content")
+
+    if os.name == "nt" or os.environ.get('SMB_FORCE', False):
+        symlink("%s\\dir2\\file2" % smb_share, "%s\\dir2\\file3" % smb_share)
 
     assert exists("%s\\dir2" % smb_share) is True
 
@@ -62,12 +66,11 @@ def test_copy2(smb_share):
         fd.write(u"content")
 
     sleep(0.1)
-    copy2("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share)
+    copy("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share)
 
     src_stat = stat("%s\\file1" % smb_share)
     dst_stat = stat("%s\\dir2\\file1" % smb_share)
-    assert src_stat.st_atime == dst_stat.st_atime
-    assert src_stat.st_mtime == dst_stat.st_mtime
+
     assert src_stat.st_size == dst_stat.st_size
 
 
@@ -79,12 +82,12 @@ def test_copy2_raises_when_source_and_target_identical(smb_share):
     sleep(0.1)
     if (sys.version_info > (3, 0)):
         expected = 'are the same file'
-        context = pytest.raises(Error, match=re.escape(expected))
+        context = pytest.raises(ValueError, match=re.escape(expected))
     else:
-        context = pytest.raises(Error)
+        context = pytest.raises(ValueError)
 
     with context:
-        copy2("%s\\file1" % smb_share, "%s\\file1" % smb_share)
+        copy("%s\\file1" % smb_share, "%s\\file1" % smb_share)
 
 
 def test_copy2_with_dir_as_target(smb_share):
@@ -93,12 +96,11 @@ def test_copy2_with_dir_as_target(smb_share):
         fd.write(u"content")
 
     sleep(0.1)
-    copy2("%s\\file1" % smb_share, "%s\\dir2" % smb_share)
+    copy("%s\\file1" % smb_share, "%s\\dir2" % smb_share)
 
     src_stat = stat("%s\\file1" % smb_share)
     dst_stat = stat("%s\\dir2\\file1" % smb_share)
-    assert src_stat.st_atime == dst_stat.st_atime
-    assert src_stat.st_mtime == dst_stat.st_mtime
+
     assert src_stat.st_size == dst_stat.st_size
 
 
@@ -113,12 +115,11 @@ def test_copytree(smb_share):
         fd.write(u"content")
 
     sleep(0.01)
-    copytree("%s\\dir2" % smb_share, "%s\\dir4" % smb_share)
+    copytree_copy("%s\\dir2" % smb_share, "%s\\dir4" % smb_share)
 
     src_stat = stat("%s\\dir2\\dir3\\file1" % smb_share)
     dst_stat = stat("%s\\dir4\\dir3\\file1" % smb_share)
-    assert src_stat.st_atime == dst_stat.st_atime
-    assert src_stat.st_mtime == dst_stat.st_mtime
+
     assert src_stat.st_size == dst_stat.st_size
 
 
@@ -136,18 +137,21 @@ def test_copytree_with_skip(smb_share):
         return [name for name in names if name == "file2"]
 
     sleep(0.01)
-    copytree("%s\\dir2" % smb_share, "%s\\dir4" % smb_share, ignore=ignore)
+    copytree_copy("%s\\dir2" % smb_share, "%s\\dir4" % smb_share, ignore=ignore)
 
     assert exists("%s\\dir4\\dir3\\file1" % smb_share) is True
     assert exists("%s\\dir4\\file2" % smb_share) is False
 
 
 def test_copyfile_with_same_file(smb_share):
+    with open_file("%s\\file1" % smb_share, mode='w') as fd:
+        fd.write(u"content")
+
     if (sys.version_info > (3, 0)):
         expected = 'are the same file'
-        context = pytest.raises(Error, match=re.escape(expected))
+        context = pytest.raises(ValueError, match=re.escape(expected))
     else:
-        context = pytest.raises(Error)
+        context = pytest.raises(ValueError)
 
     with context:
         copyfile("%s\\file1" % smb_share, "%s\\file1" % smb_share)
@@ -159,19 +163,18 @@ def test_server_side_copy(smb_share):
         fd.write(u"content" * 1024)
 
     sleep(0.1)
-    copy2("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share, server_side_copy=True)
+    copy("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share, server_side_copy=True)
 
     src_stat = stat("%s\\file1" % smb_share)
     dst_stat = stat("%s\\dir2\\file1" % smb_share)
-    assert src_stat.st_atime == dst_stat.st_atime
-    assert src_stat.st_mtime == dst_stat.st_mtime
+
     assert src_stat.st_size == dst_stat.st_size
 
 
 def test_server_side_copy_across_paths_raises():
     expected = 'Server side copy can only occur on the same drive'
     with pytest.raises(ValueError, match=re.escape(expected)):
-        copyfile_server_side("//host/filer1/file1", "//host/filer2/file2")
+        _copyfile_server_side("//host/filer1/file1", "//host/filer2/file2")
 
 
 def test_server_side_copy_target_exists(smb_share):
@@ -187,7 +190,7 @@ def test_server_side_copy_target_exists(smb_share):
         context = pytest.raises(ValueError)
 
     with context:
-        copyfile_server_side("%s\\file1" % smb_share, "%s\\file2" % smb_share)
+        _copyfile_server_side("%s\\file1" % smb_share, "%s\\file2" % smb_share)
 
 
 def test_server_side_copy_multiple_chunks(smb_share):
@@ -198,10 +201,9 @@ def test_server_side_copy_multiple_chunks(smb_share):
     smbclient.shutil.CHUNK_SIZE = 1024
 
     sleep(0.1)
-    copy2("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share, server_side_copy=True)
+    copy("%s\\file1" % smb_share, "%s\\dir2\\file1" % smb_share, server_side_copy=True)
 
     src_stat = stat("%s\\file1" % smb_share)
     dst_stat = stat("%s\\dir2\\file1" % smb_share)
-    assert src_stat.st_atime == dst_stat.st_atime
-    assert src_stat.st_mtime == dst_stat.st_mtime
+
     assert src_stat.st_size == dst_stat.st_size


### PR DESCRIPTION
Added various methods like copy2, copytree etc. Also added a kwarg that allows to perform copying server side. Many methods are copied and adapted from their python2 shutil counterpart to mimic their behavior. Further, a set of integration tests that at least cover the happy paths was added. @jborean93 let me know what you think.