### PR TITLE
smbclient - fix reads on large files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.1 - TBD
 
+* Fix issue when reading a large file that exceeds 65KB and raises `STATUS_END_OF_FILE`.
+
 
 ## 1.0.0 - 2019-11-30
 

--- a/smbclient/_io.py
+++ b/smbclient/_io.py
@@ -414,14 +414,15 @@ class SMBRawIO(io.RawIOBase):
         remaining_bytes = self.fd.end_of_file - self._offset
         while len(data) < remaining_bytes or self.FILE_TYPE == 'pipe':
             try:
-                data += self.fd.read(self._offset, self._buffer_size)
+                data_part = self.fd.read(self._offset, self._buffer_size)
             except SMBResponseException as exc:
                 if exc.status == NtStatus.STATUS_PIPE_BROKEN:
                     break
                 raise
 
+            data += data_part
             if self.FILE_TYPE != 'pipe':
-                self._offset += len(data)
+                self._offset += len(data_part)
 
         return data
 

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -554,6 +554,19 @@ def test_write_byte_file(smb_share):
         assert fd.read() == b"abc"
 
 
+# https://github.com/jborean93/smbprotocol/issues/20
+def test_read_large_text_file(smb_share):
+    file_path = "%s\\%s" % (smb_share, "file.txt")
+    file_contents = u"a" * 131074
+
+    with smbclient.open_file(file_path, mode='w') as fd:
+        fd.write(file_contents)
+
+    with smbclient.open_file(file_path) as fd:
+        actual = fd.read()
+        assert len(actual) == 131074
+
+
 def test_write_exclusive_text_file(smb_share):
     file_path = "%s\\%s" % (smb_share, "file.txt")
     file_contents = u"File Contents\nNewline"


### PR DESCRIPTION
During a read we were incorrectly incrementally increasing the offset with the size of the data collection so far instead of what was read in the SMB Read operation. This PR fixes up the logic to increase the offset only by the amount of data read by each SMB call.

This was an issue before when reading files that were between 131073 and 196609 bytes (other ranges were most likely affected as well). With the previous logic, the 3rd SMB call would have an offset that is larger than the file itself resulting in an `STATUS_END_OF_FILE` exception. Now the offset should be calculated properly.

Fixes https://github.com/jborean93/smbprotocol/issues/20