### PR TITLE
Speed up logging statements when logging isn't used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.2 - TBD
+
+* Speed up logging statements for large messages like a read and write message.
+
+
 ## 1.0.1 - 2019-12-12
 
 * Fix issue when reading a large file that exceeds 65KB and raises `STATUS_END_OF_FILE`.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 setup(
     name='smbprotocol',
-    version='1.0.1',
+    version='1.0.2.dev0',
     packages=['smbclient', 'smbprotocol'],
     install_requires=[
         'cryptography>=2.0',

--- a/smbprotocol/change_notify.py
+++ b/smbprotocol/change_notify.py
@@ -250,7 +250,7 @@ class FileSystemWatcher(object):
 
         log.info("Session: %s, Tree Connect: %s , Open: %s - sending SMB2 Change Notify request"
                  % (self.open.tree_connect.session.username, self.open.tree_connect.share_name, self.open.file_name))
-        log.debug(str(change_notify))
+        log.debug(change_notify)
         if send:
             request = self.open.connection.send(change_notify, self.open.tree_connect.session.session_id,
                                                 self.open.tree_connect.tree_connect_id)

--- a/smbprotocol/connection.py
+++ b/smbprotocol/connection.py
@@ -1102,7 +1102,7 @@ class Connection(object):
                  "request of %d" % (timeout, credit_request))
 
         echo_msg = SMB2Echo()
-        log.debug(str(echo_msg))
+        log.debug(echo_msg)
         req = self.send(echo_msg, sid=sid, credit_request=credit_request)
 
         log.info("Receiving Echo response")
@@ -1111,7 +1111,7 @@ class Connection(object):
                  % response['credit_response'].get_value())
         echo_resp = SMB2Echo()
         echo_resp.unpack(response['data'].get_value())
-        log.debug(str(echo_resp))
+        log.debug(echo_resp)
 
         return response['credit_response'].get_value()
 
@@ -1442,13 +1442,13 @@ class Connection(object):
             ]
 
         log.info("Sending SMB2 Negotiate message")
-        log.debug(str(neg_req))
+        log.debug(neg_req)
         request = self.send(neg_req)
         self.preauth_integrity_hash_value.append(request.message)
 
         response = self.receive(request, timeout=timeout)
         log.info("Receiving SMB2 Negotiate response")
-        log.debug(str(response))
+        log.debug(response)
         self.preauth_integrity_hash_value.append(response)
 
         smb_response = SMB2NegotiateResponse()

--- a/smbprotocol/open.py
+++ b/smbprotocol/open.py
@@ -1204,7 +1204,7 @@ class Open(object):
                                   self.tree_connect.share_name,
                                   self.file_name))
 
-        log.debug(str(create))
+        log.debug(create)
         request = self.connection.send(create,
                                        self.tree_connect.session.session_id,
                                        self.tree_connect.tree_connect_id)
@@ -1223,7 +1223,7 @@ class Open(object):
         create_response['create_contexts_length'] = len(create_response['buffer'])
 
         self._connected = True
-        log.debug(str(create_response))
+        log.debug(create_response)
 
         self.file_id = create_response['file_id'].get_value()
         self.tree_connect.session.open_table[self.file_id] = self
@@ -1298,7 +1298,7 @@ class Open(object):
                  "Request for file %s" % (self.tree_connect.session.username,
                                           self.tree_connect.share_name,
                                           self.file_name))
-        log.debug(str(read))
+        log.debug(read)
         request = self.connection.send(read,
                                        self.tree_connect.session.session_id,
                                        self.tree_connect.tree_connect_id)
@@ -1311,7 +1311,7 @@ class Open(object):
         response = self.connection.receive(request, wait=wait)
         read_response = SMB2ReadResponse()
         read_response.unpack(response['data'].get_value())
-        log.debug(str(read_response))
+        log.debug(read_response)
 
         return read_response['buffer'].get_value()
 
@@ -1373,7 +1373,7 @@ class Open(object):
                  "for file %s" % (self.tree_connect.session.username,
                                   self.tree_connect.share_name,
                                   self.file_name))
-        log.debug(str(write))
+        log.debug(write)
         request = self.connection.send(write,
                                        self.tree_connect.session.session_id,
                                        self.tree_connect.tree_connect_id)
@@ -1386,7 +1386,7 @@ class Open(object):
         response = self.connection.receive(request, wait=wait)
         write_response = SMB2WriteResponse()
         write_response.unpack(response['data'].get_value())
-        log.debug(str(write_response))
+        log.debug(write_response)
 
         return write_response['count'].get_value()
 
@@ -1415,7 +1415,7 @@ class Open(object):
                  "for file %s" % (self.tree_connect.session.username,
                                   self.tree_connect.share_name,
                                   self.file_name))
-        log.debug(str(flush))
+        log.debug(flush)
         request = self.connection.send(flush,
                                        self.tree_connect.session.session_id,
                                        self.tree_connect.tree_connect_id)
@@ -1428,7 +1428,7 @@ class Open(object):
         response = self.connection.receive(request)
         flush_response = SMB2FlushResponse()
         flush_response.unpack(response['data'].get_value())
-        log.debug(str(flush_response))
+        log.debug(flush_response)
         return flush_response
 
     def query_directory(self, pattern, file_information_class, flags=None,
@@ -1473,7 +1473,7 @@ class Open(object):
                  "Directory Request for directory %s"
                  % (self.tree_connect.session.username,
                     self.tree_connect.share_name, self.file_name))
-        log.debug(str(query))
+        log.debug(query)
         request = self.connection.send(query,
                                        self.tree_connect.session.session_id,
                                        self.tree_connect.tree_connect_id)
@@ -1486,7 +1486,7 @@ class Open(object):
         response = self.connection.receive(request)
         query_response = SMB2QueryDirectoryResponse()
         query_response.unpack(response['data'].get_value())
-        log.debug(str(query_response))
+        log.debug(query_response)
 
         query_request = SMB2QueryDirectoryRequest()
         query_request.unpack(request.message['data'].get_value())
@@ -1528,7 +1528,7 @@ class Open(object):
                  "for file %s" % (self.tree_connect.session.username,
                                   self.tree_connect.share_name,
                                   self.file_name))
-        log.debug(str(close))
+        log.debug(close)
         request = self.connection.send(close,
                                        self.tree_connect.session.session_id,
                                        self.tree_connect.tree_connect_id)
@@ -1551,7 +1551,7 @@ class Open(object):
 
         c_resp = SMB2CloseResponse()
         c_resp.unpack(response['data'].get_value())
-        log.debug(str(c_resp))
+        log.debug(c_resp)
         self._connected = False
         del self.tree_connect.session.open_table[self.file_id]
 

--- a/smbprotocol/session.py
+++ b/smbprotocol/session.py
@@ -416,14 +416,14 @@ class Session(object):
         log.info("Session: %s - Logging off of SMB Session" % self.username)
         logoff = SMB2Logoff()
         log.info("Session: %s - Sending Logoff message" % self.username)
-        log.debug(str(logoff))
+        log.debug(logoff)
         request = self.connection.send(logoff, sid=self.session_id)
 
         log.info("Session: %s - Receiving Logoff response" % self.username)
         res = self.connection.receive(request)
         res_logoff = SMB2Logoff()
         res_logoff.unpack(res['data'].get_value())
-        log.debug(str(res_logoff))
+        log.debug(res_logoff)
         self._connected = False
         del self.connection.session_table[self.session_id]
 

--- a/smbprotocol/tree.py
+++ b/smbprotocol/tree.py
@@ -230,7 +230,7 @@ class TreeConnect(object):
 
         log.info("Session: %s - Sending Tree Connect message"
                  % self.session.username)
-        log.debug(str(connect))
+        log.debug(connect)
         request = self.session.connection.send(connect,
                                                sid=self.session.session_id)
 
@@ -239,7 +239,7 @@ class TreeConnect(object):
         response = self.session.connection.receive(request)
         tree_response = SMB2TreeConnectResponse()
         tree_response.unpack(response['data'].get_value())
-        log.debug(str(tree_response))
+        log.debug(tree_response)
 
         # https://msdn.microsoft.com/en-us/library/cc246687.aspx
         self.tree_connect_id = response['tree_id'].get_value()
@@ -280,7 +280,7 @@ class TreeConnect(object):
         req = SMB2TreeDisconnect()
         log.info("Session: %s, Tree: %s - Sending Tree Disconnect message"
                  % (self.session.username, self.share_name))
-        log.debug(str(req))
+        log.debug(req)
         request = self.session.connection.send(req,
                                                sid=self.session.session_id,
                                                tid=self.tree_connect_id)
@@ -290,7 +290,7 @@ class TreeConnect(object):
         res = self.session.connection.receive(request)
         res_disconnect = SMB2TreeDisconnect()
         res_disconnect.unpack(res['data'].get_value())
-        log.debug(str(res_disconnect))
+        log.debug(res_disconnect)
         self._connected = False
         del self.session.tree_connect_table[self.tree_connect_id]
 
@@ -317,7 +317,7 @@ class TreeConnect(object):
         ioctl_request['flags'] = IOCTLFlags.SMB2_0_IOCTL_IS_FSCTL
         log.info("%s - Sending Secure Negotiate Validation message"
                  % log_header)
-        log.debug(str(ioctl_request))
+        log.debug(ioctl_request)
         request = self.session.connection.send(ioctl_request,
                                                sid=self.session.session_id,
                                                tid=self.tree_connect_id)
@@ -326,12 +326,12 @@ class TreeConnect(object):
         response = self.session.connection.receive(request)
         ioctl_resp = SMB2IOCTLResponse()
         ioctl_resp.unpack(response['data'].get_value())
-        log.debug(str(ioctl_resp))
+        log.debug(ioctl_resp)
 
         log.info("%s - Unpacking secure negotiate response info" % log_header)
         val_resp = SMB2ValidateNegotiateInfoResponse()
         val_resp.unpack(ioctl_resp['buffer'].get_value())
-        log.debug(str(val_resp))
+        log.debug(val_resp)
 
         self._verify("server capabilities",
                      val_resp['capabilities'].get_value(),


### PR DESCRIPTION
A common logging pattern is for smbprotocol to output the SMB2 messages sent across the write on the DEBUG level logging. This can cause a slowdown for large messages like an SMB2 Read Response or SMB2 Write Request with a large amount of data.

Instead of calling `__str__` in the `log.debug()` call we instead pass the object which has the benefit of only calling `__str__` if debug level logging is enabled. Because of this the performance hit of logging these large messages only happens if DEBUG level logs are enabled.

I can't seem to find the original reporter for this issue but thanks for bringing this to my attention if you are following this.