### PR TITLE
Create separate exception types for each status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Speed up logging statements for large messages like a read and write message
 * Changed authentication dep to [pyspnego](https://github.com/jborean93/pyspnego) that handles all the authentication work
 * Fixed up authentication against hosts that don't present the initial GSSAPI token like Azure File Storage
+* Added specific exception types for every `NtStatus` value to make it easier to catch only specific exceptions
 * Added `STATUS_SERVER_UNAVAILABLE` to the list of known exception codes
 
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ export SMB_PORT=445
 export SMB_SERVER=127.0.0.1
 export SMB_SHARE=share
 
-docker run -d -p $SMB_PORT:445 -v $(pwd)/build-scripts:/app -w /app -e SMB_USER=$SMB_USER -e SMB_PASSWORD=$SMB_PASSWORD -e SMB_SHARE=$SMB_SHARE centos:7 /bin/bash /app/setup_samba.sh;
+docker run -d --privileged=true -p $SMB_PORT:445 -v $(pwd)/build-scripts:/app -w /app -e SMB_USER=$SMB_USER -e SMB_PASSWORD=$SMB_PASSWORD -e SMB_SHARE=$SMB_SHARE centos:7 /bin/bash /app/setup_samba.sh;
 ```
 
 

--- a/smbclient/_os.py
+++ b/smbclient/_os.py
@@ -35,6 +35,8 @@ from smbprotocol._text import (
 )
 
 from smbprotocol.exceptions import (
+    NoEASOnFile,
+    NoSuchFile,
     NtStatus,
     SMBOSError,
     SMBResponseException,
@@ -230,10 +232,8 @@ def listdir(path, search_pattern="*", **kwargs):
             raw_filenames = dir_fd.query_directory(search_pattern, FileInformationClass.FILE_NAMES_INFORMATION)
             return list(e['file_name'].get_value().decode('utf-16-le') for e in raw_filenames if
                         e['file_name'].get_value().decode('utf-16-le') not in ['.', '..'])
-        except SMBResponseException as exc:
-            if exc.status == NtStatus.STATUS_NO_SUCH_FILE:
-                return []
-            raise
+        except NoSuchFile:
+            return []
 
 
 def lstat(path, **kwargs):

--- a/smbprotocol/session.py
+++ b/smbprotocol/session.py
@@ -34,10 +34,10 @@ from smbprotocol.connection import (
 )
 
 from smbprotocol.exceptions import (
+    MoreProcessingRequired,
     NtStatus,
     SMBAuthenticationError,
     SMBException,
-    SMBResponseException,
 )
 
 from smbprotocol.structure import (
@@ -273,9 +273,7 @@ class Session(object):
             log.info("Receiving SMB2_SESSION_SETUP response message")
             try:
                 response = self.connection.receive(request)
-            except SMBResponseException as exc:
-                if exc.status != NtStatus.STATUS_MORE_PROCESSING_REQUIRED:
-                    raise exc
+            except MoreProcessingRequired as exc:
                 mid = request.message['message_id'].get_value()
                 del self.connection.outstanding_requests[mid]
                 response = exc.header

--- a/tests/test_change_notify.py
+++ b/tests/test_change_notify.py
@@ -16,7 +16,8 @@ from smbprotocol.connection import (
 )
 
 from smbprotocol.exceptions import (
-    SMBResponseException,
+    InvalidParameter,
+    NotifyCleanup,
 )
 
 from smbprotocol.session import Session
@@ -383,8 +384,7 @@ class TestChangeNotify(object):
 
             open.close()
 
-            expected = "Received unexpected status from the server: (267) STATUS_NOTIFY_CLEANUP"
-            with pytest.raises(SMBResponseException, match=re.escape(expected)):
+            with pytest.raises(NotifyCleanup):
                 watcher.wait()
         finally:
             connection.disconnect(True)
@@ -451,8 +451,7 @@ class TestChangeNotify(object):
 
             watcher = FileSystemWatcher(open)
             watcher.start(CompletionFilter.FILE_NOTIFY_CHANGE_FILE_NAME)
-            expected = "Received unexpected status from the server: (3221225485) STATUS_INVALID_PARAMETER"
-            with pytest.raises(SMBResponseException, match=re.escape(expected)):
+            with pytest.raises(InvalidParameter):
                 watcher.wait()
         finally:
             connection.disconnect(True)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -125,12 +125,11 @@ class TestSMBResponseException(object):
         error_resp = SMB2ErrorResponse()
         header = self._get_header(error_resp)
         try:
-            raise SMBResponseException(header, header['status'].get_value(),
-                                       header['message_id'].get_value())
+            raise SMBResponseException(header, header['status'].get_value())
         except SMBResponseException as exc:
             assert exc.error_details == []
-            exp_resp = "Received unexpected status from the server: " \
-                       "(3221225485) STATUS_INVALID_PARAMETER: 0xc000000d"
+            exp_resp = "Received unexpected status from the server: An invalid parameter was passed to a service or " \
+                       "function. (3221225485) STATUS_INVALID_PARAMETER: 0xc000000d"
             assert exc.message == exp_resp
             assert str(exc) == exp_resp
             assert exc.status == NtStatus.STATUS_INVALID_PARAMETER
@@ -147,17 +146,14 @@ class TestSMBResponseException(object):
         header = self._get_header(error_resp,
                                   NtStatus.STATUS_STOPPED_ON_SYMLINK)
         try:
-            raise SMBResponseException(header, header['status'].get_value(),
-                                       header['message_id'].get_value())
+            raise SMBResponseException(header, header['status'].get_value())
         except SMBResponseException as exc:
             assert len(exc.error_details) == 1
             err1 = exc.error_details[0]
             assert isinstance(err1, SMB2SymbolicLinkErrorResponse)
-            exp_resp = "Received unexpected status from the server: " \
-                       "(2147483693) STATUS_STOPPED_ON_SYMLINK: 0x8000002d " \
-                       "- Flag: (0) SYMLINK_FLAG_ABSOLUTE, " \
-                       r"Print Name: C:\temp\folder, " \
-                       r"Substitute Name: \??\C:\temp\folder"
+            exp_resp = "Received unexpected status from the server: The create operation stopped after reaching a " \
+                       "symbolic link. (2147483693) STATUS_STOPPED_ON_SYMLINK: 0x8000002d - Flag: (0) " \
+                       "SYMLINK_FLAG_ABSOLUTE, Print Name: C:\\temp\\folder, Substitute Name: \\??\\C:\\temp\\folder"
             assert exc.message == exp_resp
             assert str(exc) == exp_resp
             assert exc.status == NtStatus.STATUS_STOPPED_ON_SYMLINK
@@ -180,15 +176,14 @@ class TestSMBResponseException(object):
         header = self._get_header(error_resp,
                                   NtStatus.STATUS_BAD_NETWORK_NAME)
         try:
-            raise SMBResponseException(header, header['status'].get_value(),
-                                       header['message_id'].get_value())
+            raise SMBResponseException(header, header['status'].get_value())
         except SMBResponseException as exc:
             assert len(exc.error_details) == 1
             err1 = exc.error_details[0]
             assert isinstance(err1, SMB2ShareRedirectErrorContext)
-            exp_resp = "Received unexpected status from the server: " \
-                       "(3221225676) STATUS_BAD_NETWORK_NAME: 0xc00000cc - " \
-                       "IP Addresses: '192.168.1.100', Resource Name: resource"
+            exp_resp = "Received unexpected status from the server: The specified share name cannot be found on " \
+                       "the remote server. (3221225676) STATUS_BAD_NETWORK_NAME: 0xc00000cc - IP Addresses: " \
+                       "'192.168.1.100', Resource Name: resource"
             assert exc.message == exp_resp
             assert str(exc) == exp_resp
             assert exc.status == NtStatus.STATUS_BAD_NETWORK_NAME
@@ -200,14 +195,12 @@ class TestSMBResponseException(object):
         error_resp['error_data'] = [cont_resp]
         header = self._get_header(error_resp)
         try:
-            raise SMBResponseException(header, header['status'].get_value(),
-                                       header['message_id'].get_value())
+            raise SMBResponseException(header, header['status'].get_value())
         except SMBResponseException as exc:
             assert len(exc.error_details) == 1
             assert exc.error_details[0] == b"\x01\x02\x03\x04"
-            exp_resp = "Received unexpected status from the server: " \
-                       "(3221225485) STATUS_INVALID_PARAMETER: 0xc000000d - " \
-                       "Raw: 01020304"
+            exp_resp = "Received unexpected status from the server: An invalid parameter was passed to a service " \
+                       "or function. (3221225485) STATUS_INVALID_PARAMETER: 0xc000000d - Raw: 01020304"
             assert exc.message == exp_resp
             assert str(exc) == exp_resp
             assert exc.status == NtStatus.STATUS_INVALID_PARAMETER
@@ -223,15 +216,13 @@ class TestSMBResponseException(object):
         ]
         header = self._get_header(error_resp)
         try:
-            raise SMBResponseException(header, header['status'].get_value(),
-                                       header['message_id'].get_value())
+            raise SMBResponseException(header, header['status'].get_value())
         except SMBResponseException as exc:
             assert len(exc.error_details) == 2
             assert exc.error_details[0] == b"\x01\x02\x03\x04"
             assert exc.error_details[1] == b"\x05\x06\x07\x08"
-            exp_resp = "Received unexpected status from the server: " \
-                       "(3221225485) STATUS_INVALID_PARAMETER: 0xc000000d - " \
-                       "Raw: 01020304, Raw: 05060708"
+            exp_resp = "Received unexpected status from the server: An invalid parameter was passed to a service " \
+                       "or function. (3221225485) STATUS_INVALID_PARAMETER: 0xc000000d - Raw: 01020304, Raw: 05060708"
             assert exc.message == exp_resp
             assert str(exc) == exp_resp
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -246,6 +246,11 @@ class TestSMBResponseException(object):
         assert error_context['error_id'].get_value() == ErrorContextId.SMB2_ERROR_ID_DEFAULT
         assert error_context['error_context_data'].get_value() == b"\x01\x02\x03\x04"
 
+    def test_inherited_exception_no_code(self):
+        with pytest.raises(ValueError, match="MyError does not have the _STATUS_CODE class attribute set"):
+            class MyError(SMBResponseException):
+                pass
+
     def _get_header(self, data, status=NtStatus.STATUS_INVALID_PARAMETER):
         header = SMB2HeaderResponse()
         header['status'] = status

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -32,6 +32,7 @@ from smbprotocol.create_contexts import (
 )
 
 from smbprotocol.exceptions import (
+    EndOfFile,
     SMBException,
     SMBUnsupportedFeature,
 )
@@ -2346,11 +2347,8 @@ class TestOpen(object):
             req = connection.send(read_msg, sid=session.session_id,
                                   tid=tree.tree_connect_id)
 
-            with pytest.raises(SMBException) as exc:
+            with pytest.raises(EndOfFile) as exc:
                 open._close_response(req)
-            assert str(exc.value) == "Received unexpected status from the " \
-                                     "server: (3221225489) " \
-                                     "STATUS_END_OF_FILE: 0xc0000011"
         finally:
             connection.disconnect(True)
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -14,8 +14,8 @@ from smbprotocol.connection import (
 )
 
 from smbprotocol.exceptions import (
+    AccessDenied,
     SMBException,
-    SMBResponseException,
 )
 
 from smbprotocol.session import (
@@ -213,11 +213,8 @@ class TestTreeConnect(object):
         tree = TreeConnect(session, smb_real[5])
         try:
             session.connect()
-            with pytest.raises(SMBResponseException) as exc:
+            with pytest.raises(AccessDenied) as exc:
                 tree.connect()
-            assert str(exc.value) == "Received unexpected status from the " \
-                                     "server: (3221225506) " \
-                                     "STATUS_ACCESS_DENIED: 0xc0000022"
         finally:
             connection.disconnect(True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,17 @@
 [tox]
-envlist = py27,py35,py36,py37,py38
+envlist = lint,py27,py35,py36,py37,py38
 skip_missing_interpreters = true
 
 [testenv]
 deps =
     -r{toxinidir}/requirements-test.txt
+    -c{toxinidir}/tests/constraints.txt
 commands =
-    py.test -v --pep8 --cov smbclient --cov smbprotocol --cov-report term-missing
+    py.test -v --cov smbclinet --cov smbprotocol --cov-report term-missing
+
 passenv =
     SMB_*
+
+[testenv:lint]
+commands =
+    pycodestyle . --verbose --show-source --statistics


### PR DESCRIPTION
To make it easier to catch only a specific status this creates an exception type for each known status code.