### PR TITLE
Fix long running pipe socket broken error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `smbclient.ClientConfig()` to set global default options on new connections
 * Moved the SMB Header structures to `smbprotocol.header`
 * Added `null_terminated` option for a `TextField` value
+* Fix broken pipe errors that occur on long running connections by sending a echo request for each connection session every 10 minutes
 
 ## 1.1.0 - 2020-08-14
 


### PR DESCRIPTION
When testing a long running connection to a Windows Server it seems like if there was no activity on the session, Windows will close it. If there are no active sessions on a connection then Windows will close the connection including the socket opened by the client. This causes a broken pipe error to be raised on the first operation of any sessions on that connection if no activity has occurred.

What this PR does is to send an SMB Echo request for every session of that connection 10 minutes after no activity has occurred. Windows will close the connection at around ~16 minutes and when testing this same code with Samba I found the connection isn't closed before the request is sent.

Fixes https://github.com/jborean93/smbprotocol/issues/31