### PR TITLE
Allow passing kwargs to spnego.client from high-level API

### DIFF
--- a/smbclient/_pool.py
+++ b/smbclient/_pool.py
@@ -251,7 +251,6 @@ def get_smb_tree(path, username=None, password=None, port=445, encrypt=None, con
         'encrypt': encrypt,
         'connection_timeout': connection_timeout,
         'connection_cache': connection_cache,
-        'session_config': session_config,
     }
 
     # Normalise and check that the path contains at least 2 components, \\server\share

--- a/smbclient/_pool.py
+++ b/smbclient/_pool.py
@@ -83,19 +83,20 @@ class ClientConfig(object):
         skip_dfs (bool): Whether to skip using any DFS referral checks and treat any path as a normal path. This is
             only useful if there are problems with the DFS resolver or you wish to avoid the extra round trip(s) the
             resolver requires.
-        session_config (Optional[dict]): Extra kwargs to pass to the Session.
+        auth_protocol (str): The protocol to use for authentication. Possible values are 'negotiate', 'ntlm' or
+            'kerberos'. Defaults to 'negotiate'.
     """
 
     def __init__(self, client_guid=None, username=None, password=None, domain_controller=None, skip_dfs=False,
-                 session_config=None, **kwargs):
+                 auth_protocol='negotiate', **kwargs):
         self.client_guid = client_guid or uuid.uuid4()
         self.username = username
         self.password = password
         self.skip_dfs = skip_dfs
+        self.auth_protocol = auth_protocol
         self._domain_controller = None  # type: Optional[str]
         self._domain_cache = []  # type: List[DomainEntry]
         self._referral_cache = []  # type: List[ReferralEntry]
-        self.session_config = session_config  # type: Optional[dict]
 
         # This relies on other attributes so set this last
         self.domain_controller = domain_controller
@@ -240,7 +241,7 @@ def get_smb_tree(path, username=None, password=None, port=445, encrypt=None, con
     client_config = ClientConfig()
     username = username or client_config.username
     password = password or client_config.password
-    session_config = client_config.session_config or {}
+    auth_protocol = client_config.auth_protocol
 
     # In case we need to nest a call to get_smb_tree, preserve the kwargs here so it's easier to update them in case
     # new kwargs are added.
@@ -288,7 +289,7 @@ def get_smb_tree(path, username=None, password=None, port=445, encrypt=None, con
     server = path_split[0]
     session = register_session(server, username=username, password=password, port=port, encrypt=encrypt,
                                connection_timeout=connection_timeout, connection_cache=connection_cache,
-                               **session_config)
+                               auth_protocol=auth_protocol)
 
     share_path = "\\\\%s\\%s" % (server, path_split[1])
     tree = next((t for t in session.tree_connect_table.values() if t.share_name == share_path), None)
@@ -315,7 +316,7 @@ def get_smb_tree(path, username=None, password=None, port=445, encrypt=None, con
 
 
 def register_session(server, username=None, password=None, port=445, encrypt=None, connection_timeout=60,
-                     connection_cache=None, **kwargs):
+                     connection_cache=None, auth_protocol='negotiate'):
     """
     Creates an active connection and session to the server specified. This can be manually called to register the
     credentials of a specific server instead of defining it on the first function connecting to the server. The opened
@@ -331,7 +332,8 @@ def register_session(server, username=None, password=None, port=445, encrypt=Non
         back to False.
     :param connection_timeout: Override the timeout used for the initial connection.
     :param connection_cache: Connection cache to be used with
-    :param kwargs: Extra kwargs to pass to the Session.
+    :param auth_protocol: The protocol to use for authentication. Possible values are 'negotiate', 'ntlm' or
+        'kerberos'. Defaults to 'negotiate'.
     :return: The Session that was registered or already existed in the pool.
     """
     connection_key = "%s:%s" % (server.lower(), port)
@@ -350,7 +352,7 @@ def register_session(server, username=None, password=None, port=445, encrypt=Non
     session = next((s for s in connection.session_table.values() if username is None or s.username == username), None)
     if not session:
         session = Session(connection, username=username, password=password, require_encryption=(encrypt is True),
-                          **kwargs)
+                          auth_protocol=auth_protocol)
         session.connect()
     elif encrypt is not None:
         # We cannot go from encryption to no encryption on an existing session but we can do the opposite.

--- a/smbprotocol/connection.py
+++ b/smbprotocol/connection.py
@@ -635,7 +635,7 @@ class Connection(object):
         :param require_signing: Whether signing is required on SMB messages
             sent over this connection
         """
-        log.info("Initialising connection, guid: %s, require_singing: %s, "
+        log.info("Initialising connection, guid: %s, require_signing: %s, "
                  "server_name: %s, port: %d"
                  % (guid, require_signing, server_name, port))
         self.server_name = server_name

--- a/smbprotocol/session.py
+++ b/smbprotocol/session.py
@@ -168,7 +168,7 @@ class SMB2Logoff(Structure):
 class Session(object):
 
     def __init__(self, connection, username=None, password=None,
-                 require_encryption=True, spnego_client_config=None):
+                 require_encryption=True, auth_protocol='negotiate'):
         """
         [MS-SMB2] v53.0 2017-09-15
 
@@ -209,8 +209,9 @@ class Session(object):
         :param require_encryption: Whether any messages sent over the session
             require encryption regardless of the server settings (Dialects 3+),
             needs to be set to False for older dialects.
-        :param spnego_client_config: Configuration options to use when creating
-            the spnego client context.
+        :param auth_protocol: The protocol to use for authentication. Possible
+            values are 'negotiate', 'ntlm' or 'kerberos'. Defaults to
+            'negotiate'.
         """
         log.info("Initialising session with username: %s" % username)
         self._connected = False
@@ -230,10 +231,9 @@ class Session(object):
         self.connection = connection
         self.username = username
         self.password = password
-        if spnego_client_config is None:
-            self.spnego_client_config = {}
-        else:
-            self.spnego_client_config = spnego_client_config
+
+        # No need to validate this as the spnego library will raise a ValueError
+        self.auth_protocol = auth_protocol
 
         # Table of OpenFile, lookup by OpenFile.file_id
         self.open_table = {}
@@ -261,7 +261,7 @@ class Session(object):
         log.debug("Decoding SPNEGO token containing supported auth mechanisms")
         try:
             context = spnego.client(self.username, self.password, service='cifs', hostname=self.connection.server_name,
-                                    options=spnego.NegotiateOptions.session_key, **self.spnego_client_config)
+                                    options=spnego.NegotiateOptions.session_key, protocol=self.auth_protocol)
         except spnego.exceptions.SpnegoError as err:
             raise SMBAuthenticationError("Failed to authenticate with server: %s" % str(err.message))
 

--- a/smbprotocol/session.py
+++ b/smbprotocol/session.py
@@ -168,7 +168,7 @@ class SMB2Logoff(Structure):
 class Session(object):
 
     def __init__(self, connection, username=None, password=None,
-                 require_encryption=True):
+                 require_encryption=True, spnego_client_config=None):
         """
         [MS-SMB2] v53.0 2017-09-15
 
@@ -209,6 +209,8 @@ class Session(object):
         :param require_encryption: Whether any messages sent over the session
             require encryption regardless of the server settings (Dialects 3+),
             needs to be set to False for older dialects.
+        :param spnego_client_config: Configuration options to use when creating
+            the spnego client context.
         """
         log.info("Initialising session with username: %s" % username)
         self._connected = False
@@ -228,6 +230,10 @@ class Session(object):
         self.connection = connection
         self.username = username
         self.password = password
+        if spnego_client_config is None:
+            self.spnego_client_config = {}
+        else:
+            self.spnego_client_config = spnego_client_config
 
         # Table of OpenFile, lookup by OpenFile.file_id
         self.open_table = {}
@@ -255,7 +261,7 @@ class Session(object):
         log.debug("Decoding SPNEGO token containing supported auth mechanisms")
         try:
             context = spnego.client(self.username, self.password, service='cifs', hostname=self.connection.server_name,
-                                    options=spnego.NegotiateOptions.session_key)
+                                    options=spnego.NegotiateOptions.session_key, **self.spnego_client_config)
         except spnego.exceptions.SpnegoError as err:
             raise SMBAuthenticationError("Failed to authenticate with server: %s" % str(err.message))
 


### PR DESCRIPTION
I have added in a way to pass extra kwargs to `spnego.client`. The primary motivation behind doing this was to be able to disable NTLM fallback authentication while using the high-level API, but I think the low-level API doesn't have support for this either, so this PR will add this functionality in both places.

I have marked this as a WIP for now as I haven't written any tests, but I wanted to get it on your radar.