### PR TITLE
writeall() as a separate function without changing write()

### DIFF
--- a/smbclient/_os.py
+++ b/smbclient/_os.py
@@ -298,6 +298,13 @@ def makedirs(path, exist_ok=False, **kwargs):
             create_queue.pop(-1)
 
 
+class BufferedWriterPlusWriteAll(io.BufferedWriter):
+    def writeall(self, b, max_write_size=sys.maxsize):
+        bytes_written = 0
+        while bytes_written < len(b):
+            bytes_written += self.write(b[bytes_written:][:max_write_size])
+
+
 def open_file(path, mode='r', buffering=-1, encoding=None, errors=None, newline=None, share_access=None,
               desired_access=None, file_attributes=None, file_type='file', **kwargs):
     """

--- a/smbclient/_os.py
+++ b/smbclient/_os.py
@@ -301,7 +301,13 @@ def makedirs(path, exist_ok=False, **kwargs):
 
 class TextIOWrapperPlusWriteAll(io.TextIOWrapper):
     def writeall(self, b, max_write_size=sys.maxsize):
-        self.buffer.writeall(b, max_write_size=max_write_size)
+        """
+        TextIOWrapper.write() handles the conversion from str to bytes,
+        so we still need TextIOWrapper.write().
+        """
+        bytes_written = 0
+        while bytes_written < len(b):
+            bytes_written += self.write(b[bytes_written:][:max_write_size])
 
 
 class BufferedWriterPlusWriteAll(io.BufferedWriter):

--- a/smbclient/_os.py
+++ b/smbclient/_os.py
@@ -387,7 +387,7 @@ def open_file(path, mode='r', buffering=-1, encoding=None, errors=None, newline=
         elif raw_fd.readable():
             buff_type = io.BufferedReader
         else:
-            buff_type = io.BufferedWriter
+            buff_type = BufferedWriterPlusWriteAll
 
         if buffering == -1:
             buffering = MAX_PAYLOAD_SIZE

--- a/smbclient/_os.py
+++ b/smbclient/_os.py
@@ -11,6 +11,7 @@ import ntpath
 import operator
 import os
 import stat as py_stat
+import sys
 import time
 
 from smbclient._io import (

--- a/smbclient/_os.py
+++ b/smbclient/_os.py
@@ -299,6 +299,11 @@ def makedirs(path, exist_ok=False, **kwargs):
             create_queue.pop(-1)
 
 
+class TextIOWrapperPlusWriteAll(io.TextIOWrapper):
+    def writeall(self, b, max_write_size=sys.maxsize):
+        self.buffer.writeall(b, max_write_size=max_write_size)
+
+
 class BufferedWriterPlusWriteAll(io.BufferedWriter):
     def writeall(self, b, max_write_size=sys.maxsize):
         bytes_written = 0
@@ -397,7 +402,7 @@ def open_file(path, mode='r', buffering=-1, encoding=None, errors=None, newline=
         if 'b' in raw_fd.mode:
             return fd_buffer
 
-        return io.TextIOWrapper(fd_buffer, encoding, errors, newline, line_buffering=line_buffering)
+        return TextIOWrapperPlusWriteAll(fd_buffer, encoding, errors, newline, line_buffering=line_buffering)
     except Exception:
         # If there was a failure in the setup, make sure the file is closed.
         raw_fd.close()

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -106,6 +106,24 @@ def test_server_side_copy_multiple_chunks(smb_share):
     assert src_stat.st_size == dst_stat.st_size
 
 
+def test_write_multiple_chunks_bytes(smb_share):
+    smbclient.mkdir("%s\\dir2" % smb_share)
+    with smbclient.open_file("%s\\file1" % smb_share, mode='wb') as fd:
+        assert isinstance(fd, smbclient._os.BufferedWriterPlusWriteAll)
+        fd.write(b"File Contents\nNewline" * 1024)
+
+    assert smbclient.stat("%s\\file1" % smb_share).st_size == len(b"File Contents\nNewline") * 1024
+
+
+def test_write_multiple_chunks_text(smb_share):
+    smbclient.mkdir("%s\\dir2" % smb_share)
+    with smbclient.open_file("%s\\file1" % smb_share, mode='w') as fd:
+        assert isinstance(fd, smbclient._os.TextIOWrapperPlusWriteAll)
+        fd.write(u"content" * 1024)
+
+    assert smbclient.stat("%s\\file1" % smb_share).st_size == len(u"content") * 1024
+
+
 def test_server_side_copy_large_file(smb_share):
     src_filename = "%s\\file1" % smb_share
     dst_filename = "%s\\file2" % smb_share

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -120,12 +120,8 @@ def test_write_multiple_chunks_bytes(smb_share):
 def test_write_multiple_chunks_text(smb_share):
     smbclient.mkdir("%s\\dir2" % smb_share)
     with smbclient.open_file("%s\\file1" % smb_share, mode='w') as fd:
-        assert isinstance(fd, io.TextIOWrapper)
-        text = u"content" * 1024
-        max_write_size = 1024
-        bytes_written = 0
-        while bytes_written < len(text):
-            bytes_written += fd.write(text[bytes_written:][:max_write_size])
+        assert isinstance(fd, TextIOWrapperPlusWriteAll)
+        fd.writeall(u"content" * 1024, max_write_size=1024)
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(u"content") * 1024
     with smbclient.open_file("%s\\file1" % smb_share, mode='r') as fd:

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -109,7 +109,7 @@ def test_server_side_copy_multiple_chunks(smb_share):
 def test_write_multiple_chunks_bytes(smb_share):
     smbclient.mkdir("%s\\dir2" % smb_share)
     with smbclient.open_file("%s\\file1" % smb_share, mode='wb') as fd:
-        assert isinstance(fd, smbclient._os.BufferedWriterPlusWriteAll)
+        assert isinstance(fd, io.BufferedWriter)
         fd.write(b"File Contents\nNewline" * 1024)
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(b"File Contents\nNewline") * 1024
@@ -118,7 +118,7 @@ def test_write_multiple_chunks_bytes(smb_share):
 def test_write_multiple_chunks_text(smb_share):
     smbclient.mkdir("%s\\dir2" % smb_share)
     with smbclient.open_file("%s\\file1" % smb_share, mode='w') as fd:
-        assert isinstance(fd, smbclient._os.TextIOWrapperPlusWriteAll)
+        assert isinstance(fd, io.TextIOWrapper)
         fd.write(u"content" * 1024)
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(u"content") * 1024

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -117,6 +117,8 @@ def test_write_multiple_chunks_bytes(smb_share):
             bytes_written += fd.write(b[bytes_written:bytes_written + max_write_size])
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(b"File Contents\nNewline") * 1024
+    with smbclient.open_file("%s\\file1" % smb_share, mode='rb') as fd:
+        assert fd.read() == b"File Contents\nNewline" * 1024
 
 
 def test_write_multiple_chunks_text(smb_share):
@@ -130,6 +132,8 @@ def test_write_multiple_chunks_text(smb_share):
             bytes_written += fd.write(text[bytes_written:bytes_written + max_write_size])
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(u"content") * 1024
+    with smbclient.open_file("%s\\file1" % smb_share, mode='r') as fd:
+        assert fd.read() == u"content" * 1024
 
 
 def test_server_side_copy_large_file(smb_share):

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -110,7 +110,7 @@ def test_write_multiple_chunks_bytes(smb_share):
     smbclient.mkdir("%s\\dir2" % smb_share)
     with smbclient.open_file("%s\\file1" % smb_share, mode='wb') as fd:
         assert isinstance(fd, smbclient._os.BufferedWriterPlusWriteAll)
-        fd.write(b"File Contents\nNewline" * 1024, max_write_size=1024)
+        fd.writeall(b"File Contents\nNewline" * 1024, max_write_size=1024)
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(b"File Contents\nNewline") * 1024
     with smbclient.open_file("%s\\file1" % smb_share, mode='rb') as fd:

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -109,12 +109,8 @@ def test_server_side_copy_multiple_chunks(smb_share):
 def test_write_multiple_chunks_bytes(smb_share):
     smbclient.mkdir("%s\\dir2" % smb_share)
     with smbclient.open_file("%s\\file1" % smb_share, mode='wb') as fd:
-        assert isinstance(fd, io.BufferedWriter)
-        b = b"File Contents\nNewline" * 1024
-        max_write_size = 1024
-        bytes_written = 0
-        while bytes_written < len(b):
-            bytes_written += fd.write(b[bytes_written:][:max_write_size])
+        assert isinstance(fd, smbclient._os.BufferedWriterPlusWriteAll)
+        fd.write(b"File Contents\nNewline" * 1024, max_write_size=1024)
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(b"File Contents\nNewline") * 1024
     with smbclient.open_file("%s\\file1" % smb_share, mode='rb') as fd:

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -120,7 +120,7 @@ def test_write_multiple_chunks_bytes(smb_share):
 def test_write_multiple_chunks_text(smb_share):
     smbclient.mkdir("%s\\dir2" % smb_share)
     with smbclient.open_file("%s\\file1" % smb_share, mode='w') as fd:
-        assert isinstance(fd, TextIOWrapperPlusWriteAll)
+        assert isinstance(fd, smbclient._os.TextIOWrapperPlusWriteAll)
         fd.writeall(u"content" * 1024, max_write_size=1024)
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(u"content") * 1024

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -114,7 +114,7 @@ def test_write_multiple_chunks_bytes(smb_share):
         max_write_size = 1024
         bytes_written = 0
         while bytes_written < len(b):
-            bytes_written += fd.write(b[bytes_written:bytes_written + max_write_size])
+            bytes_written += fd.write(b[bytes_written:][:max_write_size])
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(b"File Contents\nNewline") * 1024
     with smbclient.open_file("%s\\file1" % smb_share, mode='rb') as fd:
@@ -129,7 +129,7 @@ def test_write_multiple_chunks_text(smb_share):
         max_write_size = 1024
         bytes_written = 0
         while bytes_written < len(text):
-            bytes_written += fd.write(text[bytes_written:bytes_written + max_write_size])
+            bytes_written += fd.write(text[bytes_written:][:max_write_size])
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(u"content") * 1024
     with smbclient.open_file("%s\\file1" % smb_share, mode='r') as fd:

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -110,7 +110,11 @@ def test_write_multiple_chunks_bytes(smb_share):
     smbclient.mkdir("%s\\dir2" % smb_share)
     with smbclient.open_file("%s\\file1" % smb_share, mode='wb') as fd:
         assert isinstance(fd, io.BufferedWriter)
-        fd.write(b"File Contents\nNewline" * 1024)
+        b = b"File Contents\nNewline" * 1024
+        max_write_size = 1024
+        bytes_written = 0
+        while bytes_written < len(b):
+            bytes_written += fd.write(b[bytes_written:bytes_written + max_write_size])
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(b"File Contents\nNewline") * 1024
 
@@ -119,7 +123,11 @@ def test_write_multiple_chunks_text(smb_share):
     smbclient.mkdir("%s\\dir2" % smb_share)
     with smbclient.open_file("%s\\file1" % smb_share, mode='w') as fd:
         assert isinstance(fd, io.TextIOWrapper)
-        fd.write(u"content" * 1024)
+        text = u"content" * 1024
+        max_write_size = 1024
+        bytes_written = 0
+        while bytes_written < len(text):
+            bytes_written += fd.write(text[bytes_written:bytes_written + max_write_size])
 
     assert smbclient.stat("%s\\file1" % smb_share).st_size == len(u"content") * 1024
 


### PR DESCRIPTION
This is built atop https://github.com/jborean93/smbprotocol/pull/67. Look there first. They're easier to read individually.

This might be a less invasive alternative to changing the behavior of `write()`.