### PR TITLE
Fix up credit calculation and read offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Fixed up `write()` in `smbclient.open_file()` to be able to write bytes greater than the `max_write_size`
 * Fixed issue when receiving an unknown NtStatus error code from the server
 * Added `PipeBusy` exception for `STATUS_PIPE_NOT_AVAILABLE 0xC00000AD` error responses
+* Fix credit granting calculation when receiving a compound response
+    * Original logic granted `len(responses) - 1` credits than what the server actually given causing errors when the client ran out of credits without it knowing
 
 
 ## 1.2.0 - 2020-09-22

--- a/smbclient/_io.py
+++ b/smbclient/_io.py
@@ -494,9 +494,6 @@ class SMBRawIO(io.RawIOBase):
 
             data += buffer[:bytes_read]
 
-            if self.FILE_TYPE != 'pipe':
-                self._offset += bytes_read
-
         return bytes(data)
 
     def readinto(self, b):

--- a/smbprotocol/connection.py
+++ b/smbprotocol/connection.py
@@ -1160,8 +1160,14 @@ class Connection(object):
                         self.verify_signature(header, session_id)
 
                     credit_response = header['credit_response'].get_value()
+                    if credit_response == 0 and not self.supports_multi_credit:
+                        # If the dialect does not support credits we still need to adjust our sequence window.
+                        # Otherwise the credit response may be 0 in the case of compound responses and the last
+                        # response contains the credits that were granted.
+                        credit_response += 1
+
                     with self.sequence_lock:
-                        self.sequence_window['high'] += credit_response if credit_response > 0 else 1
+                        self.sequence_window['high'] += credit_response
 
                     command = header['command'].get_value()
                     status = header['status'].get_value()


### PR DESCRIPTION
Fixes up the logic that calculates how many credits were granted by the
server. Previously we considered each message in a compound request as 1
credit even though the credit amount was 0 in the header. Instead we
need to not count those as the last header has the proper credit amount.

Also fixes an issue with the read offset being doubled when calling
`read()`. This was a recent change and not part of any release.