### PR TITLE
Fix up auth logic for non-negotiate auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed up secure negotiation logic when connecting to older SMB dialects
 * Will attempt to perform secure negotiation even on older dialects that may not implement it properly
 * Added `ClientConfig` option `require_secure_negotiate` to globally turn off secure negotiation if the client wishes
+* Fix explicit `ntlm` or `kerberos` authentication when the server response with the initial SPNEGO mech list token
 
 
 ## 1.3.0 - 2021-01-23

--- a/smbprotocol/session.py
+++ b/smbprotocol/session.py
@@ -267,8 +267,10 @@ class Session(object):
 
         self.connection.preauth_session_table[self.session_id] = self
         in_token = self.connection.gss_negotiate_token
+        if self.auth_protocol != 'negotiate':
+            in_token = None  # The GSS Negotiate Token can only be used for Negotiate auth.
 
-        while not context.complete or not in_token:
+        while not context.complete or in_token:
             try:
                 out_token = context.step(in_token)
             except spnego.exceptions.SpnegoError as err:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -327,3 +327,28 @@ class TestSession(object):
             assert session.signing_required
         finally:
             connection.disconnect(True)
+
+    def test_setup_session_with_ntlm_only(self, smb_real):
+        connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
+        connection.connect()
+
+        session = Session(connection, smb_real[0], smb_real[1], False, auth_protocol='ntlm')
+        try:
+            session.connect()
+            assert len(session.application_key) == 16
+            assert session.application_key != session.session_key
+            assert len(session.decryption_key) == 16
+            assert session.decryption_key != session.session_key
+            assert not session.encrypt_data
+            assert len(session.encryption_key) == 16
+            assert session.encryption_key != session.session_key
+            assert len(session.connection.preauth_integrity_hash_value) == 2
+            assert len(session.preauth_integrity_hash_value) == 3
+            assert not session.require_encryption
+            assert session.session_id is not None
+            assert len(session.session_key) == 16
+            assert len(session.signing_key) == 16
+            assert session.signing_key != session.session_key
+            assert session.signing_required
+        finally:
+            connection.disconnect()


### PR DESCRIPTION
The GSS Negotiation Token from the negotiation response is a [NegTokenInit2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-spng/8e71cf53-e867-4b79-b5b5-38c92be3d472) token that contains a list of mechs the server supports and is parsed by the Negotiate process when selecting the optimistic protocol. When someone explicitly requests `ntlm` or `kerberos` auth we were still passing in this token but neither pure Kerberos or NTLM is able to parse the SPNEGO token structure causing a failure when generating the first token.

This PR blanks out that token when not using `negotiate` auth and fixes a logic bug that becomes present when using pure NTLM authentication not wrapped in SPNEGO.

Fixes https://github.com/jborean93/smbprotocol/issues/74