### PR TITLE
Fix TCP Receiver Hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.5.0 - TBD
+
+* Added `smbprotocol.exceptions.SMBConnectionClosed` that is raised when trying to send or receive data on a connection that has been closed
+* Do not attempt to reuse any cached connections that have been closed in `smbclient`
+* Added a lock when writing to the socket, only 1 thread can write a message at a single point in time
+* Revamped the SMB receiver code to simplify the logic and make it more durable
+    * Removed the TCP recv thread for each connection, now each connection uses just 1 thread instead of 2
+    * Be more defensive when reading data from a socket to ensure we get all the data we require
+    * Handled server side FIN packets that close the connection unexpectedly, any requests waiting for a response will raise `SMBConnectionClosed`
+
+
 ## 1.4.0 - 2021-02-02
 
 * Fixed up secure negotiation logic when connecting to older SMB dialects

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,8 @@ stages:
           python.version: 3.7
         Python38:
           python.version: 3.8
+        Python39:
+          python.version: 3.9
 
     steps:
     - task: UsePythonVersion@0
@@ -146,6 +148,12 @@ stages:
         Python38-x64:
           python.version: 3.8
           python.arch: x64
+        Python39-x86:
+          python.version: 3.9
+          python.arch: x86
+        Python39-x64:
+          python.version: 3.9
+          python.arch: x64
 
     steps:
     - task: UsePythonVersion@0
@@ -231,7 +239,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: 3.8
+        versionSpec: 3.9
 
     - script: |
         python -m pip install twine wheel -c tests/constraints.txt

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(abs_path('README.md'), mode='rb') as fd:
 
 setup(
     name='smbprotocol',
-    version='1.4.0',
+    version='1.5.0',
     packages=['smbclient', 'smbprotocol'],
     install_requires=[
         'cryptography>=2.0',
@@ -50,5 +50,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/smbclient/_pool.py
+++ b/smbclient/_pool.py
@@ -345,7 +345,8 @@ def register_session(server, username=None, password=None, port=445, encrypt=Non
         connection_cache = _SMB_CONNECTIONS
     connection = connection_cache.get(connection_key, None)
 
-    if not connection:
+    # Make sure we ignore any connections that may have had a closed connection
+    if not connection or not connection.transport.connected:
         connection = Connection(ClientConfig().client_guid, server, port)
         connection.connect(timeout=connection_timeout)
         connection_cache[connection_key] = connection

--- a/smbprotocol/_compat.py
+++ b/smbprotocol/_compat.py
@@ -1,0 +1,27 @@
+# Copyright: (c) 2021, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type  # noqa (fixes E402 for the imports below)
+
+import sys
+
+
+# TODO: Remove once Python 2.7 is dropped, use 'raise Blah() from err' instead.
+# Slightly modified from six.reraise to make calling it simpler and more like raise Excp() from err.
+if sys.version_info[0] == 3:
+    def reraise(exc, inner=None):
+        exc.__cause__ = inner[1] if inner else sys.exc_info()[1]
+        raise exc
+
+else:
+    def _exec(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        frame = sys._getframe(1)
+        _globs_ = frame.f_globals
+        _locs_ = frame.f_locals
+        del frame
+
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    _exec("def reraise(exc, inner=None):\n    raise exc, None, inner[2] if inner else sys.exc_info()[2]")

--- a/smbprotocol/exceptions.py
+++ b/smbprotocol/exceptions.py
@@ -52,6 +52,11 @@ class SMBAuthenticationError(SMBException):
     pass
 
 
+class SMBConnectionClosed(SMBException):
+    # Used to denote the underlying TCP transport has been closed.
+    pass
+
+
 class SMBOSError(OSError, SMBException):
     """Wrapper for OSError with smbprotocol specific details.
 

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -1931,7 +1931,7 @@ def test_xattr_dont_follow(smb_share):
 
 def test_credit_calculation_with_compound_requests(smb_share):
     filename = ntpath.join(smb_share, 'file.txt')
-    
+
     connection = None
     with smbclient.open_file(filename, mode='wb') as fd:
         connection = fd.raw.fd.connection


### PR DESCRIPTION
The current mechanism used to read responses from the TCP socket is quite complex but summarised in a very simplified matters involves 2 different threads

* TCP thread
  * Constantly calls `socket.recv()` to read SMB responses and adds them to an internal queue once received
* Connection thread
  * Reads from the internal queue for any messages from the TCP thread
  * Unpacks each message and fires the request event saying it has been received

This whole mechanism does work but it's very brittle to any failures in any of those steps. If the socket is closed for whatever reason the connection thread will be notified and stop listening for more messages. The issue here is that the main thread waiting for the response is never notified of this failure causing it to hang indefinitely. There are probably some edge cases in the TCP recv code where it's not reading the full number of bytes requested causing a failure as seen in #56.

What this PR does is

* Removes the TCP thread, the connection thread will call recv() directly instead of using a queue
* Tries to harden the existing `socket.recv()` code to handle cases when the full length of bytes requests was not met
* Implements a timeout functionality to make up for the timeout offered by the internal queue
  * Needed to send the SMB Echo request every 10 minutes
* The connection thread will make sure any outstanding request wait events are set when it finishes
  * The current logic only did so on an exception and didn't handle a graceful shutdown from the server causing a hang if there were still outstanding requests
* The `SMBConnectionClosed` exception is raised when trying to send or receive anything and the socket has been closed
  * Related to the above point, if there were any outstanding requests then trying to receive that will raise `SMBConnectionClosed`
* `smbclient` will ignore any connections in the cache with a closed socket, it will create a new connection automatically.
* Closing (`.disconnect()`) a connection with a closed socket will no longer fail

One last thing I need to investigate is the code around closing the TCP socket. I've seen some sporadic messages printed to the console that seem to be exceptions but aren't treated as such. I believe it might be related to the `atexit` connection close operations for `smbclient` but I haven't fully tracked that down yet.

Fixes https://github.com/jborean93/smbprotocol/issues/56
Fixes https://github.com/jborean93/smbprotocol/issues/78