### PR TITLE
Fix up replace/rename when running on a DFS path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.5.1 - TBD
+
+* Unified DFS path handling when using any API that uses a transaction to open the file
+  * This includes `smbclient.rename` and `smbclient.replace`
+
+
+
 ## 1.5.0 - 2021-03-25
 
 * Added `smbprotocol.exceptions.SMBConnectionClosed` that is raised when trying to send or receive data on a connection that has been closed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Unified DFS path handling when using any API that uses a transaction to open the file
   * This includes `smbclient.rename` and `smbclient.replace`
-
+* Fixed up `smbclient.rename` to work with directories
 
 
 ## 1.5.0 - 2021-03-25

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(abs_path('README.md'), mode='rb') as fd:
 
 setup(
     name='smbprotocol',
-    version='1.5.0',
+    version='1.5.1',
     packages=['smbclient', 'smbprotocol'],
     install_requires=[
         'cryptography>=2.0',

--- a/smbclient/_os.py
+++ b/smbclient/_os.py
@@ -1046,11 +1046,10 @@ def _rename_information(src, dst, replace_if_exists=False, **kwargs):
         'share_access': 'rwd',
         'create_options': CreateOptions.FILE_OPEN_REPARSE_POINT,
     })
-    src_raw = SMBRawIO(src, desired_access=FilePipePrinterAccessMask.DELETE, **raw_args)
-    dst_raw = SMBRawIO(dst, desired_access=FilePipePrinterAccessMask.FILE_EXECUTE, **raw_args)
 
     # We open/close the dest (ignoring if the file does not exist) so we can resolve the DFS path and determine the
     # filename src needs to be renamed to.
+    dst_raw = SMBRawIO(dst, desired_access=FilePipePrinterAccessMask.FILE_EXECUTE, **raw_args)
     try:
         SMBFileTransaction(dst_raw).commit()
     except SMBOSError as err:
@@ -1058,7 +1057,7 @@ def _rename_information(src, dst, replace_if_exists=False, **kwargs):
             raise
 
     # We need to open source first so we can get the resolved tree to compare the volumes
-    with src_raw:
+    with SMBRawIO(src, desired_access=FilePipePrinterAccessMask.DELETE, **raw_args) as src_raw:
         # We compare the server part using the GUID in case a different alias was specified for the server. The GUID
         # should uniquely identify the server for our cases here.
         src_guid = src_raw.fd.connection.server_guid

--- a/smbprotocol/exceptions.py
+++ b/smbprotocol/exceptions.py
@@ -77,6 +77,7 @@ class SMBOSError(OSError, SMBException):
         error_details = {
             NtStatus.STATUS_OBJECT_NAME_NOT_FOUND: errno.ENOENT,
             NtStatus.STATUS_OBJECT_PATH_NOT_FOUND: errno.ENOENT,
+            NtStatus.STATUS_NOT_FOUND: errno.ENOENT,
             NtStatus.STATUS_OBJECT_NAME_COLLISION: errno.EEXIST,
             NtStatus.STATUS_PRIVILEGE_NOT_HELD: (errno.EACCES, "Required privilege not held"),
             NtStatus.STATUS_SHARING_VIOLATION: (errno.EPERM, "The process cannot access the file because it is being "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 import time
 
 from smbclient import (
+    ClientConfig,
     delete_session,
     mkdir,
 )
@@ -215,3 +216,7 @@ def smb_dfs_share(request, smb_real):
         yield dfs_path
     finally:
         rmtree(target_share_path, username=smb_real[0], password=smb_real[1], port=smb_real[3])
+
+        config = ClientConfig()
+        config._domain_cache = []
+        config._referral_cache = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,7 +178,7 @@ def smb_real():
 @pytest.fixture(params=[
     ('share', 4),
     ('share-encrypted', 5),
-])
+], ids=['share', 'share-encrypted'])
 def smb_share(request, smb_real):
     # Use some non ASCII chars to test out edge cases by default.
     share_path = u"%s\\%s" % (smb_real[request.param[1]], u"Pýtæs†-[%s] 💩" % time.time())
@@ -199,7 +199,7 @@ def smb_share(request, smb_real):
     ('', None),  # Root, no referral targets
     ('share', 4),  # Simple referral to a single target
     ('share-encrypted', 5),  # Referral to 2 targets, first is known to be broken
-])
+], ids=['dfs-root', 'dfs-single-target', 'dfs-broken-target'])
 def smb_dfs_share(request, smb_real):
     test_folder = u"Pýtæs†-[%s] 💩" % time.time()
 

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -1048,8 +1048,10 @@ def test_rename_fail_dst_not_absolute(smb_share):
 
 def test_rename_fail_dst_different_root(smb_share):
     expected = "Cannot rename a file to a different root than the src."
+    server = [p for p in ntpath.normpath(smb_share).split("\\") if p][0]
+
     with pytest.raises(ValueError, match=re.escape(expected)):
-        smbclient.rename(smb_share, "\\\\server2\\share\\dst")
+        smbclient.rename(smb_share, "\\\\%s\\dfs\\dst" % server)
 
 
 def test_renames(smb_share):
@@ -1971,6 +1973,48 @@ def test_dfs_path(smb_dfs_share):
             assert info.path == test_dir
             assert info.is_dir()
             assert not info.is_file()
+
+
+def test_dfs_path_rename(smb_dfs_share):
+    test_dir = ntpath.join(smb_dfs_share, 'test folder')
+    smbclient.mkdir(test_dir)
+
+    test_file = ntpath.join(smb_dfs_share, 'test file.txt')
+    with smbclient.open_file(test_file, mode='wb') as fd:
+        fd.write(b'test data')
+
+    dst_dfs_path = ntpath.join(test_dir, 'target renamed.txt')
+    smbclient.rename(test_file, dst_dfs_path)
+
+    assert smbclient.listdir(smb_dfs_share) == ['test folder']
+    assert smbclient.listdir(test_dir) == ['target renamed.txt']
+
+    with smbclient.open_file(dst_dfs_path, mode='rb') as fd:
+        assert fd.read() == b'test data'
+
+
+def test_dfs_path_replace(smb_dfs_share):
+    test_dir = ntpath.join(smb_dfs_share, 'test folder')
+    smbclient.mkdir(test_dir)
+
+    test_file = ntpath.join(smb_dfs_share, 'test file.txt')
+    with smbclient.open_file(test_file, mode='wb') as fd:
+        fd.write(b'other data')
+
+    dst_dfs_path = ntpath.join(test_dir, 'target renamed.txt')
+    with smbclient.open_file(dst_dfs_path, mode='wb') as fd:
+        fd.write(b'test data')
+
+    smbclient.replace(dst_dfs_path, test_file)
+
+    actual_contents = smbclient.listdir(smb_dfs_share)
+    assert 'test folder' in actual_contents
+    assert 'test file.txt' in actual_contents
+
+    assert smbclient.listdir(test_dir) == []
+
+    with smbclient.open_file(test_file, mode='rb') as fd:
+        assert fd.read() == b'test data'
 
 
 def test_broken_dfs_path(smb_real):


### PR DESCRIPTION
It turns out anything being opened as a SMBFileTransaction does not handle the path being part of a DFS path. This PR moves the DFS resolver to the transaction commit code and also adjusts the logic for `rename` and `replace` to validate the volume based on the resolved path and not just what the input strings are.

Fixes https://github.com/jborean93/smbprotocol/issues/85