### PR TITLE
Use a named function when checking whether a path is remote.

### DIFF
--- a/smbclient/shutil.py
+++ b/smbclient/shutil.py
@@ -62,7 +62,7 @@ from smbprotocol.structure import (
 )
 
 
-def is_remote_path(path):
+def is_remote_path(path):  # type: (str) -> bool
     """
     Returns True iff the given path is a remote SMB path (rather than a local path).
 

--- a/smbclient/shutil.py
+++ b/smbclient/shutil.py
@@ -62,7 +62,7 @@ from smbprotocol.structure import (
 )
 
 
-def is_remote_path(path) -> bool:
+def is_remote_path(path):
     """
     Returns True iff the given path is a remote SMB path (rather than a local path).
 


### PR DESCRIPTION
Ultimately I want to extend `copytree` to allow copying to local, but as a first step towards that, this moves out the check for a remote path to a named function.