### PR TITLE
Fix up connection cache for scandir and rmtree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Unified DFS path handling when using any API that uses a transaction to open the file
   * This includes `smbclient.rename` and `smbclient.replace`
 * Fixed up `smbclient.rename` to work with directories
+* `smbclient.scandir` will continue to use the connection cache when getting stat information of a dir entry
+* `smbclient.shutil.rmtree` will continue to use the connection cache when removing child entries
 
 
 ## 1.5.0 - 2021-03-25

--- a/smbclient/shutil.py
+++ b/smbclient/shutil.py
@@ -408,19 +408,19 @@ def rmtree(path, ignore_errors=False, onerror=None, **kwargs):
         if dir_entry.is_symlink() and \
                 dir_entry.stat(follow_symlinks=False).st_file_attributes & FileAttributes.FILE_ATTRIBUTE_DIRECTORY:
             try:
-                rmdir(dir_entry.path)
+                rmdir(dir_entry.path, **kwargs)
             except OSError:
                 onerror(rmdir, dir_entry.path, sys.exc_info())
         elif dir_entry.is_dir():
-            rmtree(dir_entry.path, ignore_errors, onerror)
+            rmtree(dir_entry.path, ignore_errors, onerror, **kwargs)
         else:
             try:
-                remove(dir_entry.path)
+                remove(dir_entry.path, **kwargs)
             except OSError:
                 onerror(remove, dir_entry.path, sys.exc_info())
 
     try:
-        rmdir(path)
+        rmdir(path, **kwargs)
     except OSError:
         onerror(rmdir, path, sys.exc_info())
 


### PR DESCRIPTION
The values of `scandir` can then go on to call `stat` which currently fails if `scandir` was originally called with a custom cache. This fixes up that logic so subsequent calls continue to use that cache.

This also fixes up `rmtree` where it didn't continue to use the cache when removing directory children.

Fixes https://github.com/jborean93/smbprotocol/issues/87