### PR TITLE
Bump version and drop python 2.7/3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.6.0 - TBD
+
+* Dropped support for Python 2.7 and 3.5
+
+
 ## 1.5.1 - 2021-05-08
 
 * Unified DFS path handling when using any API that uses a transaction to open the file

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,10 +33,6 @@ stages:
       smb_share: share
     strategy:
       matrix:
-        Python27:
-          python.version: 2.7
-        Python35:
-          python.version: 3.5
         Python36:
           python.version: 3.6
         Python37:
@@ -118,18 +114,6 @@ stages:
       vmImage: windows-2019
     strategy:
       matrix:
-        Python27-x86:
-          python.version: 2.7
-          python.arch: x86
-        Python27-x64:
-          python.version: 2.7
-          python.arch: x64
-        Python35-x86:
-          python.version: 3.5
-          python.arch: x86
-        Python35-x64:
-          python.version: 3.5
-          python.arch: x64
         Python36-x86:
           python.version: 3.6
           python.arch: x86

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(abs_path('README.md'), mode='rb') as fd:
 
 setup(
     name='smbprotocol',
-    version='1.5.1',
+    version='1.6.0',
     packages=['smbclient', 'smbprotocol'],
     install_requires=[
         'cryptography>=2.0',
@@ -31,7 +31,7 @@ setup(
             'gssapi>=1.4.1',
         ],
     },
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
+    python_requires='>=3.6',
     author='Jordan Borean',
     author_email='jborean93@gmail.com',
     url='https://github.com/jborean93/smbprotocol',
@@ -43,10 +43,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,2 +1,0 @@
-# Other constraints
-pytest >= 3.6 ; python_version > "2.7"  # Make sure other Python versions use a newer version of pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py27,py35,py36,py37,py38
+envlist = lint,py36,py37,py38,py39
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
It's time to move on, this is getting harder to run in CI and people on these versions can still continue to use older releases fi they wish.

Fixes https://github.com/jborean93/smbprotocol/issues/94