### PR TITLE
Ignore ENOTCONN socket errors

### DIFF
--- a/smbprotocol/transport.py
+++ b/smbprotocol/transport.py
@@ -88,9 +88,10 @@ class Tcp(object):
                 # which returns b'' meaning it was closed.
                 try:
                     self._sock.shutdown(socket.SHUT_RDWR)
-                except socket.error as e:
+                except socket.error as e: #pragma: no cover
+                    # Avoid collecting coverage here to avoid CI failing due to race condition differences
                     if e.errno != errno.ENOTCONN:
-                        raise  # pragma: no cover
+                        raise  
 
                 # This is even more special, we cannot close the socket if we are in the middle of a select or recv().
                 # Doing so causes either a timeout (bad!) or bad fd descriptor (somewhat bad). By shutting down the

--- a/smbprotocol/transport.py
+++ b/smbprotocol/transport.py
@@ -88,7 +88,7 @@ class Tcp(object):
                 # which returns b'' meaning it was closed.
                 try:
                     self._sock.shutdown(socket.SHUT_RDWR)
-                except socket.error as e: #pragma: no cover
+                except socket.error as e:  # pragma: no cover
                     # Avoid collecting coverage here to avoid CI failing due to race condition differences
                     if e.errno != errno.ENOTCONN:
                         raise  

--- a/smbprotocol/transport.py
+++ b/smbprotocol/transport.py
@@ -91,7 +91,7 @@ class Tcp(object):
                 except socket.error as e:  # pragma: no cover
                     # Avoid collecting coverage here to avoid CI failing due to race condition differences
                     if e.errno != errno.ENOTCONN:
-                        raise  
+                        raise
 
                 # This is even more special, we cannot close the socket if we are in the middle of a select or recv().
                 # Doing so causes either a timeout (bad!) or bad fd descriptor (somewhat bad). By shutting down the

--- a/smbprotocol/transport.py
+++ b/smbprotocol/transport.py
@@ -86,7 +86,11 @@ class Tcp(object):
 
                 # Sending shutdown first will tell the recv thread (for both select and recv) that the socket has data
                 # which returns b'' meaning it was closed.
-                self._sock.shutdown(socket.SHUT_RDWR)
+                try:
+                    self._sock.shutdown(socket.SHUT_RDWR)
+                except socket.error as e:
+                    if e.errno != errno.ENOTCONN:
+                        raise  # pragma: no cover
 
                 # This is even more special, we cannot close the socket if we are in the middle of a select or recv().
                 # Doing so causes either a timeout (bad!) or bad fd descriptor (somewhat bad). By shutting down the


### PR DESCRIPTION
Address the (presumably) Linux-specific race condition in socket.shutdown()

See https://github.com/FreeOpcUa/python-opcua/issues/739 for a similar issue/fix