### PR TITLE
Run tests on macOS with Python 3.9.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+#
+# Available MS hosted OSes
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted
+#
 trigger:
   branches:
     include:
@@ -25,7 +29,7 @@ stages:
 
   - job: Test_Linux
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: $(vmImage)
     variables:
       smb_port: 445
       smb_user: smbuser
@@ -35,12 +39,19 @@ stages:
       matrix:
         Python36:
           python.version: 3.6
+          vmImage: ubuntu-16.04
         Python37:
           python.version: 3.7
+          vmImage: ubuntu-20.04
         Python38:
           python.version: 3.8
+          vmImage: ubuntu-20.04
         Python39:
           python.version: 3.9
+          vmImage: ubuntu-20.04
+        Python39MacOs:
+          python.version: 3.9
+          vmImage: macOS-10.15
 
     steps:
     - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,7 @@
 #
+# Docs for YAML schema
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
+#
 # Available MS hosted OSes
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted
 #
@@ -29,7 +32,7 @@ stages:
 
   - job: Test_Linux
     pool:
-      vmImage: $(vmImage)
+      vmImage: ubuntu-18.04
     variables:
       smb_port: 445
       smb_user: smbuser
@@ -39,19 +42,12 @@ stages:
       matrix:
         Python36:
           python.version: 3.6
-          vmImage: ubuntu-16.04
         Python37:
           python.version: 3.7
-          vmImage: ubuntu-20.04
         Python38:
           python.version: 3.8
-          vmImage: ubuntu-20.04
         Python39:
           python.version: 3.9
-          vmImage: ubuntu-20.04
-        Python39MacOs:
-          python.version: 3.9
-          vmImage: macOS-10.15
 
     steps:
     - task: UsePythonVersion@0
@@ -98,6 +94,49 @@ stages:
         SMB_USER: $(smb_user)
         SMB_PASSWORD: $(smb_pass)
         SMB_SHARE: $(smb_share)
+      displayName: Test
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFiles: '**/test-*.xml'
+        testRunTitle: $(Agent.OS) - $(Build.BuildNumber) - Python $(python.version)
+      displayName: Publish test results
+      condition: succeededOrFailed()
+
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        codeCoverageTool: Cobertura
+        summaryFileLocation: $(System.DefaultWorkingDirectory)/**/coverage.xml
+
+    - script: |
+        bash <(curl -s https://codecov.io/bash)
+      displayName: Upload to codecov.io
+      continueOnError: true
+      timeoutInMinutes: 5
+
+
+  - job: Test_MacOs
+    pool:
+      vmImage: macOS-10.15
+
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.9
+
+    - script: |
+        echo "Installing baseline pip packages"
+        python -m pip install --upgrade pip setuptools wheel coverage -c tests/constraints.txt
+
+        echo "Installing test requirements"
+        python -m pip install -r requirements-test.txt -c tests/constraints.txt
+
+        echo "Installing package"
+        python -m pip install . -c tests/constraints.txt
+      displayName: Install
+
+    - script: |
+        pytest -v --junitxml junit/test-results.xml --cov smbclient --cov smbprotocol --cov-report xml --cov-report term-missing
       displayName: Test
 
     - task: PublishTestResults@2

--- a/tests/test_smbclient_shutil.py
+++ b/tests/test_smbclient_shutil.py
@@ -605,6 +605,8 @@ def test_copymode_local_to_local_symlink_follow(tmpdir):
     assert stat.S_IMODE(actual_link) & stat.S_IWRITE == stat.S_IWRITE
 
 
+@pytest.mark.skipif(sys.platform.startswith('darwin'),
+                    reason="On macOS os.chmod supports symlinks.")
 def test_copymode_local_to_local_symlink_dont_follow(tmpdir):
     test_dir = tmpdir.mkdir('test')
     src_filename = "%s\\source.txt" % test_dir
@@ -858,6 +860,8 @@ def test_copystat_local_to_local_symlink_follow(tmpdir):
     assert stat.S_IMODE(actual_link.st_mode) & stat.S_IWRITE == stat.S_IWRITE
 
 
+@pytest.mark.skipif(sys.platform.startswith('darwin'),
+                    reason="On macOS os.chmod supports symlinks.")
 def test_copystat_local_to_local_symlink_dont_follow_fail(tmpdir):
     test_dir = tmpdir.mkdir('test')
     src_filename = "%s\\source.txt" % test_dir


### PR DESCRIPTION
Fixes #119

This adds macOS tests runs.

I have only enabled macOS as these jobs are slow ...and I think that 3.9 should be the most popular version.
If errors are found on macOS with other Python version, we can later extend the matrix.

The is some yaml duplication, but I didn't want to add template as I think that the duplication can be managed.

The Samba docker tests are skipped on macOS.

It looks like the test failing on macOS were just some test to check that os.chmod is used and are not tests for smbprotocol.
I have skipped them.

--------------

I don't know how to install docker on macOS from CLI.
I guess that instead of docker, we can also have samba installed via homebrew and configured in Azure and executed in the background 

Or try to run some tests via macOS native SMB server `pwpolicy -u TEST_USER -sethashtypes SMB-NT on`