### PR TITLE
Fix up credit charge calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add performance improvement on reads with large files
 * Added the `require_signing` kwarg to `smbclient.register_session()` to allow the caller to control whether signing is required on the connection or not
 * Fix `OverflowError` when handling FILETIME values beyond the year 9999 - caps the value to `9999-12-31` due to a Python limitation
+* Fix up credit charge calculation which causes a `STATUS_INVALID_PARAMETER` response for certain read/write lengths
 
 
 ## 1.5.1 - 2021-05-08


### PR DESCRIPTION
Turns out the logic I had for calculating the credit charge was incorrect. The existing logic failed when attempting a read of `262145` bytes as the code was thinking it cost 4 credits instead of 5. This PR adjusts the credit calculation for this scenario.

Fixes https://github.com/jborean93/smbprotocol/issues/112