### PR TITLE
Remove outstanding requests on failures as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added the `require_signing` kwarg to `smbclient.register_session()` to allow the caller to control whether signing is required on the connection or not
 * Fix `OverflowError` when handling FILETIME values beyond the year 9999 - caps the value to `9999-12-31` due to a Python limitation
 * Fix up credit charge calculation which causes a `STATUS_INVALID_PARAMETER` response for certain read/write lengths
+* Ensure responses with a failure are cleaned up from the outstanding request table to avoid memory leaks
 
 
 ## 1.5.1 - 2021-05-08

--- a/smbprotocol/session.py
+++ b/smbprotocol/session.py
@@ -292,7 +292,6 @@ class Session(object):
                 response = self.connection.receive(request)
             except MoreProcessingRequired as exc:
                 mid = request.message['message_id'].get_value()
-                del self.connection.outstanding_requests[mid]
                 response = exc.header
 
             # If this is the first time we received the actual session_id, update the preauth table with the server


### PR DESCRIPTION
We never removed the requests from the outstanding request table if the status wasn't a success or pending. This results in the requests building up over time for operations that expect a failure message like `smbclient.listdir()`. Instead we always clear the request from the outstanding table unless

* it's a pending response and we are waiting - the final response will delete it
* it's a stopped on symlink - the redirected request response will delete it

Fixes https://github.com/jborean93/smbprotocol/issues/127