### PR TITLE
Fix up domain_controller ClientConfig authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.2 - TBD
+
+* Fix up cached credential logic when setting `domain_controller` in the initial config singleton
+
 ## 1.6.1 - 2021-07-29
 
 * Remove `print()` statement that was used during testing

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(abs_path('README.md'), mode='rb') as fd:
 
 setup(
     name='smbprotocol',
-    version='1.6.1',
+    version='1.6.2',
     packages=['smbclient', 'smbprotocol'],
     install_requires=[
         'cryptography>=2.0',


### PR DESCRIPTION
Setting the `domain_controller` will kick of an IPC tree connect which will try to get an instance of that config for the credentials to use. Since the config instance is not stored in the singleton dict it would now be a brand new config without any credentials causing a failure if Kerberos wasn't used. This method ensures that `domain_controller` is only ever set once all the other properties are when creating a new instance.

Fixes https://github.com/jborean93/smbprotocol/issues/109