### PR TITLE
Connection health checks

### DIFF
--- a/smbprotocol/connection.py
+++ b/smbprotocol/connection.py
@@ -83,7 +83,6 @@ from smbprotocol.structure import (
 )
 
 from smbprotocol.transport import (
-    _TimeoutError,
     Tcp,
 )
 
@@ -1115,7 +1114,7 @@ class Connection(object):
                 # https://github.com/jborean93/smbprotocol/issues/31
                 try:
                     b_msg = self.transport.recv(600)
-                except _TimeoutError as ex:
+                except TimeoutError as ex:
                     # Check if the connection has unanswered keepalive echo requests with the reserved field set.
                     # When unanswered keep alive echo exists, the server did not respond withing two times the timeout.
                     # We assume that the server connection is dead and close it.

--- a/smbprotocol/connection.py
+++ b/smbprotocol/connection.py
@@ -1115,7 +1115,18 @@ class Connection(object):
                 # https://github.com/jborean93/smbprotocol/issues/31
                 try:
                     b_msg = self.transport.recv(600)
-                except _TimeoutError:
+                except _TimeoutError as ex:
+                    # Check if the connection has unanswered keepalive echo requests with the reserved field set.
+                    # When unanswered keep alive echo exists, the server did not respond withing two times the timeout.
+                    # We assume that the server connection is dead and close it.
+                    for r in self.outstanding_requests.values():
+                        if r.response is None and \
+                                r.message['command'].get_value() == Commands.SMB2_ECHO and \
+                                r.message['reserved'].get_value() == 1:
+                            # connection will be closed in finally block
+                            raise SMBConnectionClosed('Connection timed out. Server did not respond within timeout.') \
+                                from ex
+
                     log.debug("Sending SMB2 Echo to keep connection alive")
                     for sid in self.session_table.keys():
                         req = self.send(SMB2Echo(), sid=sid)

--- a/smbprotocol/transport.py
+++ b/smbprotocol/transport.py
@@ -23,11 +23,6 @@ from smbprotocol.structure import (
 log = logging.getLogger(__name__)
 
 
-# TODO: Replace with TimeoutError when Python 2.7 is dropped
-class _TimeoutError(Exception):
-    pass
-
-
 class DirectTCPPacket(Structure):
     """
     [MS-SMB2] v53.0 2017-09-15
@@ -143,7 +138,7 @@ class Tcp(object):
                 timeout = timeout - (timeit.default_timer() - start_time)
                 if not read:
                     log.debug("Socket recv(%s) timed out")
-                    raise _TimeoutError()
+                    raise TimeoutError()
 
                 try:
                     b_data = self._sock.recv(read_len)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -939,6 +939,35 @@ class TestConnection(object):
         assert isinstance(mock_send.call_args[0][0], SMB2Echo)
         assert mock_send.call_args[1] == {'sid': 1}
 
+    def test_message_worker_timeout_connection_dead(self, mocker):
+        connection = Connection(uuid.uuid4(), 'server', 445, True)
+        connection.dialect = Dialects.SMB_2_1_0
+
+        mock_session = mocker.MagicMock()
+        mock_session.session_id = 1
+        mock_session.signing_key = b'test'
+        mock_session.encryption_key = b'\x00' * 16
+        connection.session_table[mock_session.session_id] = mock_session
+
+        mock_transport = mocker.MagicMock()
+        connection.transport = mock_transport
+        connection.transport.recv.side_effect = (TimeoutError, TimeoutError)
+
+        mock_disconnect = mocker.MagicMock()
+        connection.disconnect = mock_disconnect
+
+        # Not the best test but better than waiting 10 minutes for the socket to timeout.
+        connection._process_message_thread()
+
+        # First timeout: keepalive echo sent
+        assert mock_transport.send.call_count == 1
+        assert mock_transport.send.call_args[0][0]['session_id'].get_value() == mock_session.session_id
+
+        # Second timeout: close connection
+        assert mock_disconnect.call_count == 1
+        with pytest.raises(SMBConnectionClosed):
+            connection.receive(None)
+
     def test_verify_fail_no_session(self, smb_real):
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3], True)
         connection.connect()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -55,10 +55,6 @@ from smbprotocol.session import (
     Session,
 )
 
-from smbprotocol.transport import (
-    _TimeoutError,
-)
-
 
 def test_valid_hash_algorithm():
     expected = hashlib.sha512
@@ -934,7 +930,7 @@ class TestConnection(object):
 
         mock_transport = mocker.MagicMock()
         connection.transport = mock_transport
-        connection.transport.recv.side_effect = (_TimeoutError, b'')
+        connection.transport.recv.side_effect = (TimeoutError, b'')
 
         # Not the best test but better than waiting 10 minutes for the socket to timeout.
         connection._process_message_thread()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -11,7 +11,6 @@ import threading
 import time
 
 from smbprotocol.transport import (
-    _TimeoutError,
     DirectTCPPacket,
     Tcp,
 )
@@ -122,7 +121,7 @@ def server_test_small_recv(server):
 def test_recv_timeout(server_tcp):
     server_tcp.connect()
 
-    with pytest.raises(_TimeoutError):
+    with pytest.raises(TimeoutError):
         server_tcp.recv(1)
 
     server_tcp.send(b'\x00')


### PR DESCRIPTION
This PR implements health checks for server connections to prevent infinite blocks. 

When the server connection gets lost and no data is received anymore, the receiving thread waits infinitely. After 10 minutes a `TimeoutError` is raised in `transport.recv()` and a keepalive message gets sent to the server.
However, there were no checks in place if the server actually answers the keepalive echo requests, which lead to an infinite timeout loop.

My implementation checks on timeouts, whether unanswered keepalive echo requests exist. These keepalives are only sent during (previous) timeouts. When such keepalives exist, that means the server did not respond within `2 * timeout`. Then we assume that the connection is dead and close it.

 Relates https://github.com/jborean93/smbprotocol/issues/117