### PR TITLE
Support not following symlinks in SMBDirEntry.from_path

### DIFF
--- a/smbclient/_os.py
+++ b/smbclient/_os.py
@@ -1219,8 +1219,8 @@ class SMBDirEntry(object):
             return self._lstat
 
     @classmethod
-    def from_path(cls, path, **kwargs):
-        file_stat = stat(path, **kwargs)
+    def from_path(cls, path, follow_symlinks=True, **kwargs):
+        file_stat = stat(path, follow_symlinks=follow_symlinks, **kwargs)
 
         # A DirEntry only needs these 2 properties to be set
         dir_info = FileIdFullDirectoryInformation()


### PR DESCRIPTION
`stat()` supports `follow_symlinks=False` passed in `kwargs`, but `SMBRawIO(path, **kwargs)` does not and raises an Exception. 