### PR TITLE
Add missing FileAttributes

### DIFF
--- a/smbprotocol/file_info.py
+++ b/smbprotocol/file_info.py
@@ -89,6 +89,10 @@ class FileAttributes(object):
     FILE_ATTRIBUTE_TEMPORARY = 0x00000100
     FILE_ATTRIBUTE_INTEGRITY_STREAM = 0x00008000
     FILE_ATTRIBUTE_NO_SCRUB_DATA = 0x00020000
+    FILE_ATTRIBUTE_RECALL_ON_OPEN = 0x00040000
+    FILE_ATTRIBUTE_PINNED = 0x00080000
+    FILE_ATTRIBUTE_UNPINNED = 0x00100000
+    FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS = 0x00400000
 
 
 class FileInformationClass(object):
@@ -296,6 +300,7 @@ class FileAttributeTagInformation(Structure):
             ('file_attributes', FlagField(
                 size=4,
                 flag_type=FileAttributes,
+                flag_strict=False,
             )),
             ('reparse_tag', EnumField(
                 size=4,
@@ -324,6 +329,7 @@ class FileBasicInformation(Structure):
             ('file_attributes', FlagField(
                 size=4,
                 flag_type=FileAttributes,
+                flag_strict=False,
             )),
             ('reserved', IntField(size=4)),
         ])
@@ -351,7 +357,8 @@ class FileBothDirectoryInformation(Structure):
             ('allocation_size', IntField(size=8)),
             ('file_attributes', FlagField(
                 size=4,
-                flag_type=FileAttributes
+                flag_type=FileAttributes,
+                flag_strict=False,
             )),
             ('file_name_length', IntField(
                 size=4,
@@ -398,7 +405,8 @@ class FileDirectoryInformation(Structure):
             ('allocation_size', IntField(size=8)),
             ('file_attributes', FlagField(
                 size=4,
-                flag_type=FileAttributes
+                flag_type=FileAttributes,
+                flag_strict=False,
             )),
             ('file_name_length', IntField(
                 size=4,
@@ -480,7 +488,8 @@ class FileFullDirectoryInformation(Structure):
             ('allocation_size', IntField(size=8)),
             ('file_attributes', FlagField(
                 size=4,
-                flag_type=FileAttributes
+                flag_type=FileAttributes,
+                flag_strict=False,
             )),
             ('file_name_length', IntField(
                 size=4,
@@ -569,7 +578,8 @@ class FileIdBothDirectoryInformation(Structure):
             ('allocation_size', IntField(size=8)),
             ('file_attributes', FlagField(
                 size=4,
-                flag_type=FileAttributes
+                flag_type=FileAttributes,
+                flag_strict=False,
             )),
             ('file_name_length', IntField(
                 size=4,
@@ -618,7 +628,8 @@ class FileIdFullDirectoryInformation(Structure):
             ('allocation_size', IntField(size=8)),
             ('file_attributes', FlagField(
                 size=4,
-                flag_type=FileAttributes
+                flag_type=FileAttributes,
+                flag_strict=False,
             )),
             ('file_name_length', IntField(
                 size=4,

--- a/smbprotocol/open.py
+++ b/smbprotocol/open.py
@@ -459,7 +459,8 @@ class SMB2CreateResponse(Structure):
             ('end_of_file', IntField(size=8)),
             ('file_attributes', FlagField(
                 size=4,
-                flag_type=FileAttributes
+                flag_type=FileAttributes,
+                flag_strict=False,
             )),
             ('reserved2', IntField(size=4)),
             ('file_id', BytesField(size=16)),
@@ -554,7 +555,8 @@ class SMB2CloseResponse(Structure):
             ('end_of_file', IntField(size=8)),
             ('file_attributes', FlagField(
                 size=4,
-                flag_type=FileAttributes
+                flag_type=FileAttributes,
+                flag_strict=False,
             ))
         ])
         super(SMB2CloseResponse, self).__init__()


### PR DESCRIPTION
Hi,

I have added new flags to `FileAttributes` from [2.6 File Attributes](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ca28ec38-f155-4768-81d6-4bfeb8586fc9). The missing flag definitions prevented parsing responses with such flags set.

I also suggest to make `FileAttributes` a non-strict flag (`flag_strict=False`). In case more flags are added in the future, they should be ignored and not prevent parsing responses. This is similar to how file systems handle unknown flags:
> Note: File systems silently ignore any attribute that is not supported by that file system.  Unsupported attributes MUST NOT be persisted on the media. It is recommended that unsupported attributes be masked off when encountered. 