### PR TITLE
Add path to smbclient import and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## FUTURE - TBD
+## 1.9.0 - 2022-02-01
 
 * Fix connection cache reuse for some DFS referral requests
+* Add `smbclient.path` to the `smbclient` import allowing `import smbclient; smbclient.path.func()`
 
 
 ## 1.8.3 - 2021-11-19

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(abs_path('README.md'), mode='rb') as fd:
 
 setup(
     name='smbprotocol',
-    version='1.8.3',
+    version='1.9.0',
     packages=['smbclient', 'smbprotocol'],
     install_requires=[
         'cryptography>=2.0',

--- a/smbclient/__init__.py
+++ b/smbclient/__init__.py
@@ -3,6 +3,7 @@
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
 import logging
+import smbclient.path
 
 from smbclient._pool import (
     ClientConfig,
@@ -51,12 +52,5 @@ from smbclient._os import (
     XATTR_REPLACE,
 )
 
-try:
-    from logging import NullHandler
-except ImportError:  # pragma: no cover
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
 logger = logging.getLogger(__name__)
-logger.addHandler(NullHandler())
+logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
Adds `smbclient.path` to `smbclient` allowing easier imports and utilisation of that library.

Fixes https://github.com/jborean93/smbprotocol/issues/157