### PR TITLE
Improve DFS file opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Moved all setuptools configuration, except extension information, to `pyproject.toml`
 * Migrated project layout to a `src` based structure rather than including it in the project root
 * Allow `smbclient.copyfile` to copy files on the same server and not just the same share
+* Improve DFS opens by setting the DFS operation header flag when opening a file on a share marked as a DFS share
 
 ## 1.9.0 - 2022-02-01
 

--- a/src/smbclient/_io.py
+++ b/src/smbclient/_io.py
@@ -351,6 +351,9 @@ class SMBRawIO(io.RawIOBase):
         self, path, mode="r", share_access=None, desired_access=None, file_attributes=None, create_options=0, **kwargs
     ):
         tree, fd_path = get_smb_tree(path, **kwargs)
+        if tree.is_dfs_share:
+            fd_path = "\\".join(p for p in path.split("\\") if p)
+
         self.share_access = share_access
         self.fd = Open(tree, fd_path)
         self._mode = mode

--- a/src/smbclient/_io.py
+++ b/src/smbclient/_io.py
@@ -351,6 +351,16 @@ class SMBRawIO(io.RawIOBase):
         self, path, mode="r", share_access=None, desired_access=None, file_attributes=None, create_options=0, **kwargs
     ):
         tree, fd_path = get_smb_tree(path, **kwargs)
+
+        # When opening a file on a DFS tree the raw path used in the CREATE
+        # request is the the original DFS path as the server should normalise
+        # it and return STATUS_PATH_NOT_COVERED if it's served by a DFS target
+        # server. The fd_path returned by get_smb_tree is still kept as it's
+        # needed for rename operations that need the tree relative path to
+        # rename files/dirs to.
+        # https://github.com/jborean93/smbprotocol/issues/170
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/448cb979-7321-4598-89df-e5c97135b566
+        self._fd_path = fd_path
         if tree.is_dfs_share:
             fd_path = "\\".join(p for p in path.split("\\") if p)
 

--- a/src/smbclient/_os.py
+++ b/src/smbclient/_os.py
@@ -1131,7 +1131,7 @@ def _rename_information(src, dst, replace_if_exists=False, **kwargs):
         with SMBFileTransaction(src_raw) as transaction:
             file_rename = FileRenameInformation()
             file_rename["replace_if_exists"] = replace_if_exists
-            file_rename["file_name"] = to_text(dst_raw.fd.file_name)
+            file_rename["file_name"] = to_text(dst_raw._fd_path)
             set_info(transaction, file_rename)
 
 


### PR DESCRIPTION
Ensure that opening a file on a DFS marked share contains the
SMB2_FLAGS_DFS_OPERATIONS flag and create filename contains the DFS path
to parse and not just the tree relative path.

Related https://github.com/jborean93/smbprotocol/issues/170.