### PR TITLE
Fix negotiate request context padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Migrated project layout to a `src` based structure rather than including it in the project root
 * Allow `smbclient.copyfile` to copy files on the same server and not just the same share
 * Improve DFS opens by setting the DFS operation header flag when opening a file on a share marked as a DFS share
+* Fix negotiate request padding when using a hostname with a length of 8 characters
 
 ## 1.9.0 - 2022-02-01
 

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -307,9 +307,7 @@ class SMB3NegotiateRequest(Structure):
         data_length = struct.unpack("<H", data[2:4])[0]
         negotiate_context = SMB2NegotiateContextRequest()
         negotiate_context.unpack(data[: data_length + 8])
-        padded_size = data_length % 8
-        if padded_size != 0:
-            padded_size = 8 - padded_size
+        padded_size = 8 - (data_length % 8 or 8)
 
         return negotiate_context, data[8 + data_length + padded_size :]
 
@@ -376,7 +374,7 @@ class SMB2NegotiateContextRequest(Structure):
 
     def _padding_size(self, structure):
         data_size = len(structure["data"])
-        return 8 - data_size if data_size <= 8 else 8 - (data_size % 8)
+        return 8 - (data_size % 8 or 8)
 
 
 class SMB2PreauthIntegrityCapabilities(Structure):


### PR DESCRIPTION
When using a negotiate request with a hostname that is a multiple of 8 bytes the code will add 8 extra padding bytes. While this works on some servers others are stricter and can fail the request. This commit fixes up the padding to ensure no padding is used if the length of a context request aligns with the 8 byte boundary it is in.

Fixes: https://github.com/jborean93/smbprotocol/issues/199