### PR TITLE
Raise original BadNetworkName error on DFS failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.1 - TBD
+
+* Raise the original `BadNetworkName` error if the server doesn't indicate it supports DFS or `FSDriverRequired` was raised trying to lookup the DFS information - https://github.com/jborean93/smbprotocol/issues/196
+
 ## 1.10.0 - 2022-11-07
 
 * Require Python 3.7 or newer (dropped 3.6)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smbprotocol"
-version = "1.10.0"
+version = "1.10.1"
 description = "Interact with a server using the SMB 2/3 Protocol"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
When attempting to resolve the DFS path on a BadNetworkName error it may error with a DFS related error message. This error should be ignored if the error was stating DFS is unavailable. The whole check can also be avoided entirely if the server does not indicate it supports DFS in the capabilities it sends back.

Fixes: https://github.com/jborean93/smbprotocol/issues/196