### PR TITLE
adding support for remote to local operations in shutil.py::copytree

### DIFF
--- a/src/smbclient/shutil.py
+++ b/src/smbclient/shutil.py
@@ -281,7 +281,7 @@ def copytree(
     source path and the destination path as arguments. By default copy() is used, but any function that supports the
     same signature (like copy()) can be used.
 
-    In this current form, copytree() only supports remote to remote copies over SMB.
+    In this current form, copytree() only supports remote to remote copies over SMB, or remote to local copies.
 
     :param src: The source directory to copy.
     :param dst: The destination directory to copy to.
@@ -296,7 +296,11 @@ def copytree(
     :return: The dst path.
     """
     dir_entries = list(scandir(src, **kwargs))
-    makedirs(dst, exist_ok=dirs_exist_ok, **kwargs)
+
+    if is_remote_path(dst):
+        makedirs(dst, exist_ok=dirs_exist_ok, **kwargs)
+    else:
+        os.makedirs(dst, exist_ok=dirs_exist_ok)
 
     ignored = []
     if ignore is not None:

--- a/tests/test_smbclient_shutil.py
+++ b/tests/test_smbclient_shutil.py
@@ -1149,6 +1149,33 @@ def test_copytree_with_ignore(smb_share):
         assert fd.read() == "file3.txt"
 
 
+def test_copytree_with_local_dst(smb_share, tmp_path):
+    src_dirname = "%s\\source" % smb_share
+    dst_dirname = str(tmp_path / "target")
+
+    makedirs("%s\\dir1\\subdir1" % src_dirname)
+    with open_file("%s\\file1.txt" % src_dirname, mode="w") as fd:
+        fd.write("file1.txt")
+    with open_file("%s\\dir1\\file2.txt" % src_dirname, mode="w") as fd:
+        fd.write("file2.txt")
+    with open_file("%s\\dir1\\subdir1\\file3.txt" % src_dirname, mode="w") as fd:
+        fd.write("file3.txt")
+
+    actual = copytree(src_dirname, dst_dirname)
+    assert actual == dst_dirname
+
+    assert sorted(list(os.listdir(dst_dirname))) == ["dir1", "file1.txt"]
+    assert sorted(list(os.listdir(os.path.join(dst_dirname, "dir1")))) == ["file2.txt", "subdir1"]
+    assert sorted(list(os.listdir(os.path.join(dst_dirname, "dir1", "subdir1")))) == ["file3.txt"]
+
+    with open(os.path.join(dst_dirname, "file1.txt")) as fd:
+        assert fd.read() == "file1.txt"
+    with open(os.path.join(dst_dirname, "dir1", "file2.txt")) as fd:
+        assert fd.read() == "file2.txt"
+    with open(os.path.join(dst_dirname, "dir1", "subdir1", "file3.txt")) as fd:
+        assert fd.read() == "file3.txt"
+
+
 @pytest.mark.skipif(
     os.name != "nt" and not os.environ.get("SMB_FORCE", False), reason="Samba does not update timestamps"
 )


### PR DESCRIPTION
Step 1 to address https://github.com/jborean93/smbprotocol/issues/221

Splitting this into two PRs.

I had trouble getting the tests to work locally (even the unit tests that don't need an actual samba share to talk to), but tested manually. I am expecting the test I added to pass in CI