### PR TITLE
adding support for local to remote operations in shutil.py::copytree

### DIFF
--- a/src/smbclient/_os.py
+++ b/src/smbclient/_os.py
@@ -1172,6 +1172,24 @@ def _set_basic_information(
         set_info(transaction, basic_info)
 
 
+class LocalDirEntry:
+    """Mimics the structure of SMBDirEntry, but instead encapsulates a directory/file on a local filesystem"""
+
+    def __init__(self, path) -> None:
+        self.path = path
+
+    @property
+    def name(self):
+        """The entry's base filename, relative to the os.listdir() path argument."""
+        return os.path.basename(self.path)
+
+    def is_symlink(self):
+        return os.path.islink(self.path)
+
+    def is_dir(self):
+        return os.path.isdir(self.path)
+
+
 class SMBDirEntry:
     def __init__(self, raw, dir_info, connection_cache=None):
         self._smb_raw = raw

--- a/src/smbclient/_os.py
+++ b/src/smbclient/_os.py
@@ -1172,24 +1172,6 @@ def _set_basic_information(
         set_info(transaction, basic_info)
 
 
-class LocalDirEntry:
-    """Mimics the structure of SMBDirEntry, but instead encapsulates a directory/file on a local filesystem"""
-
-    def __init__(self, path) -> None:
-        self.path = path
-
-    @property
-    def name(self):
-        """The entry's base filename, relative to the os.listdir() path argument."""
-        return os.path.basename(self.path)
-
-    def is_symlink(self):
-        return os.path.islink(self.path)
-
-    def is_dir(self):
-        return os.path.isdir(self.path)
-
-
 class SMBDirEntry:
     def __init__(self, raw, dir_info, connection_cache=None):
         self._smb_raw = raw

--- a/src/smbclient/shutil.py
+++ b/src/smbclient/shutil.py
@@ -11,7 +11,7 @@ import stat
 import sys
 
 from smbclient._io import SMBFileTransaction, SMBRawIO, query_info, set_info
-from smbclient._os import LocalDirEntry, SMBDirEntry
+from smbclient._os import SMBDirEntry
 from smbclient._os import copyfile as smbclient_copyfile
 from smbclient._os import (
     is_remote_path,
@@ -296,7 +296,7 @@ def copytree(
     if is_remote_path(src):
         dir_entries = list(scandir(src, **kwargs))
     else:
-        dir_entries = [LocalDirEntry(os.path.join(src, result)) for result in os.listdir(src)]
+        dir_entries = list(os.scandir(src))
 
     if is_remote_path(dst):
         makedirs(dst, exist_ok=dirs_exist_ok, **kwargs)

--- a/tests/test_smbclient_shutil.py
+++ b/tests/test_smbclient_shutil.py
@@ -1176,6 +1176,33 @@ def test_copytree_with_local_dst(smb_share, tmp_path):
         assert fd.read() == "file3.txt"
 
 
+def test_copytree_with_local_src(smb_share, tmp_path):
+    src_dirname = str(tmp_path / "source")
+    dst_dirname = "%s\\target" % smb_share
+
+    os.makedirs(os.path.join(src_dirname, "dir1", "subdir1"))
+    with open(os.path.join(src_dirname, "file1.txt"), mode="w") as fd:
+        fd.write("file1.txt")
+    with open(os.path.join(src_dirname, "dir1", "file2.txt"), mode="w") as fd:
+        fd.write("file2.txt")
+    with open(os.path.join(src_dirname, "dir1", "subdir1", "file3.txt"), mode="w") as fd:
+        fd.write("file3.txt")
+
+    actual = copytree(src_dirname, dst_dirname)
+    assert actual == dst_dirname
+
+    assert sorted(list(listdir(dst_dirname))) == ["dir1", "file1.txt"]
+    assert sorted(list(listdir("%s\\dir1" % dst_dirname))) == ["file2.txt", "subdir1"]
+    assert sorted(list(listdir("%s\\dir1\\subdir1" % dst_dirname))) == ["file3.txt"]
+
+    with open_file("%s\\file1.txt" % dst_dirname) as fd:
+        assert fd.read() == "file1.txt"
+    with open_file("%s\\dir1\\file2.txt" % dst_dirname) as fd:
+        assert fd.read() == "file2.txt"
+    with open_file("%s\\dir1\\subdir1\\file3.txt" % dst_dirname) as fd:
+        assert fd.read() == "file3.txt"
+
+
 @pytest.mark.skipif(
     os.name != "nt" and not os.environ.get("SMB_FORCE", False), reason="Samba does not update timestamps"
 )


### PR DESCRIPTION
pt. 2 of addressing https://github.com/jborean93/smbprotocol/issues/221

Tackling symlinks looks a little daunting, so I'd like to circle back after making sure my current approach is aligned with the project.

It crossed my mind to have both `LocalDirEntry` and `SMBDirEntry` inherit from the same abstract class, but I've opted to keep it simple