### PR TITLE
Do not setup logging in libraries

### DIFF
--- a/src/smbclient/__init__.py
+++ b/src/smbclient/__init__.py
@@ -2,8 +2,6 @@
 # Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-import logging
-
 import smbclient.path
 from smbclient._io import SEEK_CUR, SEEK_END, SEEK_SET
 from smbclient._os import (
@@ -45,6 +43,3 @@ from smbclient._pool import (
     register_session,
     reset_connection_cache,
 )
-
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())

--- a/src/smbprotocol/__init__.py
+++ b/src/smbprotocol/__init__.py
@@ -2,13 +2,6 @@
 # Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-import logging
-from logging import NullHandler
-
-logger = logging.getLogger(__name__)
-logger.addHandler(NullHandler())
-
-
 MAX_PAYLOAD_SIZE = 65536
 
 


### PR DESCRIPTION
I found that your library modifies logger settings.

This should be done explicitly by user or application which uses the library, but never library itself.