### PR TITLE
Combine coverage before upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
         python -m pip install build
         python -m build
 
+    - name: Install smbprotocol
+      run: |
+        pip install ./dist/*.whl
+
     - name: Upload built smbprotocol
       uses: actions/upload-artifact@v3
       with:
@@ -91,11 +95,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-arch }}
 
-    - uses: actions/download-artifact@v3
-      with:
-        name: artifact
-        path: ./dist
-
     - name: Extract OS name
       shell: bash
       run: |
@@ -107,9 +106,21 @@ jobs:
       shell: bash
       run: |
         if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
-            build_helpers/run-ci.sh
+            build_helpers/run-ci.sh requirements lint start-server tests
         else
-            sudo -E build_helpers/run-ci.sh
+            sudo -E build_helpers/run-ci.sh requirements lint start-server tests
+        fi
+      env:
+        PYTEST_ADDOPTS: --color=yes
+
+    - name: Stop SMV Server
+      if: always()
+      shell: bash
+      run: |
+        if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
+            build_helpers/run-ci.sh stop-server
+        else
+            sudo -E build_helpers/run-ci.sh stop-server
         fi
       env:
         PYTEST_ADDOPTS: --color=yes
@@ -119,26 +130,60 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Unit Test Results (${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.python-arch }})
-        path: ./junit/test-results.xml
+        path: ./reports/junit/*
 
     - name: Upload Coverage Results
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: Coverage Results (${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.python-arch }})
-        path: ./coverage.xml
+        path: ./reports/coverage/*
+
+  tests_done:
+    name: Tests done
+    runs-on: ubuntu-latest
+    needs:
+    - test
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Select python
+      uses: actions/setup-python@v4
+
+    - name: Download all coverage reports
+      uses: actions/download-artifact@v3
+      with:
+        path: reports/coverage
+
+    - name: Move coverage data to the root folder
+      run: find reports/coverage -type f -exec mv '{}' reports/coverage/ \;
+
+    - name: Combine coverage
+      shell: bash
+      run: |
+        if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
+            build_helpers/run-ci.sh requirements coverage
+        else
+            sudo -E build_helpers/run-ci.sh requirements combine-coverage
+        fi
 
     - name: Upload Coverage to codecov
-      if: always()
       uses: codecov/codecov-action@v3
       with:
-        files: ./coverage.xml
-        flags: ${{ steps.os.outputs.name }},py${{ matrix.python-version }},${{ matrix.python-arch }}
+        files: ./reports/coverage/coverage.xml
+
+    - name: Upload Coverage Results
+      uses: actions/upload-artifact@v3
+      with:
+        name: Coverage Results Total
+        path: ./reports/coverage/coverage.xml
 
   publish:
     name: publish
     needs:
-    - test
+    - tests_done
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+reports/
 
 # Translations
 *.mo

--- a/build_helpers/lib.sh
+++ b/build_helpers/lib.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-
-lib::setup::smb_server() {
+lib::server::start() {
     if [ x"${GITHUB_ACTIONS}" = "xtrue" ]; then
         echo "::group::Setting up SMB Server"
     fi
@@ -29,11 +28,15 @@ lib::setup::smb_server() {
         export SMB_USER=smbuser
         export SMB_PASSWORD=smbpass
 
+        docker stop smbserver || true
+        docker rm smbserver || true
+
         docker run \
             --detach \
             --rm \
+            --name smbserver \
             --publish ${SMB_PORT}:445 \
-            --volume $( pwd )/build_helpers:/app:z \
+            --volume "$(pwd)/build_helpers:/app:z" \
             --workdir /app \
             debian:12 \
             /bin/bash \
@@ -41,7 +44,6 @@ lib::setup::smb_server() {
             ${SMB_SHARE} \
             ${SMB_USER} \
             ${SMB_PASSWORD}
-
     fi
 
     if [ x"${GITHUB_ACTIONS}" = "xtrue" ]; then
@@ -49,25 +51,33 @@ lib::setup::smb_server() {
     fi
 }
 
-lib::setup::python_requirements() {
+lib::server::stop() {
+    if [ x"${GITHUB_ACTIONS}" = "xtrue" ]; then
+        echo "::group::Setting up SMB Server"
+    fi
+
+    if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
+        echo "Running on Windows, cannot stop server"
+    elif [ "$(uname)" == "Darwin" ]; then
+        echo "Running on macOS, no Docker available in CI, skipping integration tests"
+    else
+        docker stop smbserver || true
+        docker rm smbserver || true
+    fi
+
+    if [ x"${GITHUB_ACTIONS}" = "xtrue" ]; then
+        echo "::endgroup::"
+    fi
+}
+
+lib::requirements::install() {
     if [ x"${GITHUB_ACTIONS}" = "xtrue" ]; then
         echo "::group::Installing Python Requirements"
     fi
 
     echo "Installing smbprotocol"
-    # Getting the version is important so that pip prioritises our local dist
-    python -m pip install build
-    PACKAGE_VERSION="$( python -c "import build.util; print(build.util.project_wheel_metadata('.').get('Version'))" )"
 
-    if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
-        DIST_LINK_PATH="$( echo "${PWD}/dist" | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/' )"
-    else
-        DIST_LINK_PATH="${PWD}/dist"
-    fi
-
-    python -m pip install smbprotocol=="${PACKAGE_VERSION}" \
-        --find-links "file://${DIST_LINK_PATH}" \
-        --verbose
+    python -m pip install -e .
 
     echo "Installing dev dependencies"
     python -m pip install -r requirements-dev.txt
@@ -100,15 +110,32 @@ lib::tests::run() {
         python ./build_helpers/check-smb.py
     fi
 
-    python -m pytest \
+    python_version=$(python -c 'import platform; print(platform.python_version())')
+    platform=$(python -c 'import platform; print(platform.platform())')
+
+    python -m coverage run \
+        --rcfile=tests/.coveragerc \
+        -m pytest \
         --verbose \
-        --junitxml junit/test-results.xml \
-        --cov smbclient \
-        --cov smbprotocol \
-        --cov-report xml \
-        --cov-report term-missing
+        --junitxml reports/junit/python-${python_version}-${platform}.xml
 
     if [ x"${GITHUB_ACTIONS}" = "xtrue" ]; then
         echo "::endgroup::"
+    fi
+}
+
+lib::coverage::erase() {
+    coverage erase --rcfile=tests/.coveragerc
+}
+
+lib::coverage::combine() {
+    if [ x"${GITHUB_ACTIONS}" = "xtrue" ]; then
+        echo "::group::Combining coverage"
+        python -m coverage combine --rcfile=tests/.coveragerc
+        python -m coverage xml --rcfile=tests/.coveragerc -o reports/coverage/coverage.xml -i
+        echo "::endgroup::"
+    else
+        python -m coverage combine --rcfile=tests/.coveragerc
+        python -m coverage report --rcfile=tests/.coveragerc -m
     fi
 }

--- a/build_helpers/run-ci.sh
+++ b/build_helpers/run-ci.sh
@@ -2,12 +2,38 @@
 
 # Set by GHA setup-python
 if [[ -n "${pythonLocation}" ]]; then
-    PATH="${pythonLocation}/bin:${PATH}"
+  PATH="${pythonLocation}/bin:${PATH}"
 fi
 
 source ./build_helpers/lib.sh
 
-lib::setup::smb_server
-lib::setup::python_requirements
-lib::sanity::run
-lib::tests::run
+if [[ "$#" == 0 ]]; then
+  set "$@" requirements lint coverage-erase start-server tests stop-server coverage-combine
+fi
+
+while [[ "$#" > 0 ]]; do
+  case "$1" in
+  "requirements")
+    lib::requirements::install
+    ;;
+  "lint")
+    lib::sanity::run
+    ;;
+  "tests")
+    lib::tests::run
+    ;;
+  "start-server")
+    lib::server::start
+    ;;
+  "stop-server")
+    lib::server::stop
+    ;;
+  "erase-coverage")
+    lib::coverage::erase
+    ;;
+  "combine-coverage")
+    lib::coverage::combine
+    ;;
+  esac
+  shift
+done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ exclude = '''
   | \.mypy_cache
   | \.tox
   | \.venv
+  | venv
   | _build
   | buck-out
   | build
@@ -75,7 +76,9 @@ deps =
     -r{toxinidir}/requirements-dev.txt
 
 commands =
-    python -m pytest -v --cov smbclient --cov smbprotocol --cov-report term-missing
+    python -m coverage run --rcfile=tests/.coveragerc -m pytest -v
+    python -m coverage combine --rcfile=tests/.coveragerc
+    python -m coverage report --rcfile=tests/.coveragerc -m
 
 passenv =
     SMB_*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+coverage
 black == 23.3.0
 build
 cryptography >= 2.0
@@ -5,6 +6,5 @@ isort == 5.11.5
 pre-commit
 pyspnego
 pytest
-pytest-cov
 pytest-mock
 tox

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+branch = True
+omit = tests/*
+parallel = true
+relative_files = true
+data_file = reports/coverage/.coverage
+source =
+  smbprotocol
+  smbclient


### PR DESCRIPTION
While working on #234 I've found that each matrix jobs sends coverage to Codecov. Different environment have different number of tests running (for example, on MacOS integration tests are skipped), and this leads to reporting wrong coverage information until all matrix jobs are finished.

Here I've separated running tests & saving the coverage info and combining & sending coverage report to CodeCov. This is done by switching from pytest-cov to coverage package.

Also updated `run-ci.sh` script, allowing to explicitly pass names of steps which should be run. This allows retry failed steps, or force stop SMB server container if tests are failed.
Default behavior remains the same, all steps are run.