### PR TITLE
Fix DFS recurision for missing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix up pre authenticated session id lookups that were failing with Linux ksmbd
 * Removes `logging.NullHandler()` being set in the root `smbprotocol` namespace
 * Adds basic support for remote to local and vice versa file operations with `smbclient.shutil.copytree`
+* Fixes DFS infinite recursion error when dealing with a file that does not exist on a DFS namespace
 
 ## 1.10.1 - 2022-11-14
 

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -2131,3 +2131,10 @@ def test_broken_dfs_path(smb_real):
     # error and that it doesn't continuously loop.
     with pytest.raises(SMBOSError):
         smbclient.listdir(dfs_path, username=smb_real[0], password=smb_real[1], port=smb_real[3])
+
+
+def test_dfs_nonexisting_path(smb_dfs_share):
+    fake_file = ntpath.join(smb_dfs_share, "missing file.txt")
+
+    with pytest.raises(SMBOSError):
+        smbclient.lstat(fake_file)


### PR DESCRIPTION
The code that handles a missing path does not currently record existing DFS target servers that have been tried resulting in a recursion error. By ensuring a DFS target is only retried if it hasn't already it should avoid this recursion problem.

Fixes: https://github.com/jborean93/smbprotocol/issues/228