### PR TITLE
Add smb_info to a scandir result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 1.12.1 - TBD
+## 1.13.0 - TBD
+
+* Added the property `smb_info` on `SMBDirEntry` which returns a named tuple `SMBDirEntryInformation` containing metadata already retrieved in the `scandir` operation.
+  * This avoid having to call `stat()` to retrieve data like the file attributes or datetime fields that is already available
 
 ## 1.12.0 - 2023-11-09
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smbprotocol"
-version = "1.12.1"
+version = "1.13.0"
 description = "Interact with a server using the SMB 2/3 Protocol"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/smbclient/__init__.py
+++ b/src/smbclient/__init__.py
@@ -7,6 +7,7 @@ from smbclient._os import (
     XATTR_CREATE,
     XATTR_REPLACE,
     SMBDirEntry,
+    SMBDirEntryInformation,
     SMBStatResult,
     SMBStatVolumeResult,
     copyfile,

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -1,6 +1,7 @@
 # Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
+import datetime
 import io
 import locale
 import ntpath
@@ -1231,6 +1232,19 @@ def test_scandir(smb_share):
         assert isinstance(dir_entry, SMBDirEntry)
         names.append(dir_entry.name)
 
+        entry_info = dir_entry.smb_info
+        assert isinstance(entry_info, smbclient.SMBDirEntryInformation)
+        assert isinstance(entry_info.creation_time, datetime.datetime)
+        assert isinstance(entry_info.last_access_time, datetime.datetime)
+        assert isinstance(entry_info.last_write_time, datetime.datetime)
+        assert isinstance(entry_info.change_time, datetime.datetime)
+        assert isinstance(entry_info.end_of_file, int)
+        assert isinstance(entry_info.allocation_size, int)
+        assert isinstance(entry_info.file_attributes, int)
+        assert isinstance(entry_info.ea_size, int)
+        assert isinstance(entry_info.file_id, int)
+        assert isinstance(entry_info.file_name, str)
+
         # Test out dir_entry for specific file and dir examples
         if dir_entry.name == "subdir1":
             assert str(dir_entry) == "<SMBDirEntry: 'subdir1'>"
@@ -1259,7 +1273,7 @@ def test_scandir(smb_share):
     assert "file.txt" in names
 
 
-def test_scamdir_with_pattern(smb_share):
+def test_scandir_with_pattern(smb_share):
     for filename in ["file.txt", "file-test1.txt", "file-test1a.txt"]:
         with smbclient.open_file(rf"{smb_share}\{filename}", mode="w") as fd:
             fd.write("content")


### PR DESCRIPTION
Adds the property smb_info to the scandir enumerated result which contains the already retrieved metadata on the file during the scan operation. This provides a more efficient way for callers to retrieve information like the file times, sizes, attributes straight away without having to call .stat() which results in another SMB request to the server.

Fixes: https://github.com/jborean93/smbprotocol/issues/250