### PR TITLE
Use UTC tzinfo datetime values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Added the property `smb_info` on `SMBDirEntry` which returns a named tuple `SMBDirEntryInformation` containing metadata already retrieved in the `scandir` operation.
   * This avoid having to call `stat()` to retrieve data like the file attributes or datetime fields that is already available
+* Ensure `DateTimeField` values are set to `UTC` timezones as FILETIME values are in UTC
+* Stop using `datetime.datetime.utcfromtimestamp()` as it has been deprecated
 
 ## 1.12.0 - 2023-11-09
 

--- a/src/smbprotocol/structure.py
+++ b/src/smbprotocol/structure.py
@@ -659,7 +659,12 @@ class DateTimeField(Field):
         elif isinstance(value, int):
             time_microseconds = (value - self.EPOCH_FILETIME) // 10
             try:
-                datetime_value = datetime.datetime(1970, 1, 1) + datetime.timedelta(microseconds=time_microseconds)
+                datetime_value = datetime.datetime(
+                    year=1970,
+                    month=1,
+                    day=1,
+                    tzinfo=datetime.timezone.utc,
+                ) + datetime.timedelta(microseconds=time_microseconds)
             except OverflowError:
                 # This is unfortunately but 9999 is the max value a datetime can be so we just default to that
                 datetime_value = datetime.datetime.max

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3,7 +3,7 @@
 
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -675,10 +675,24 @@ class TestSMB2NegotiateResponse:
         assert actual["max_read_size"].get_value() == 8388608
         assert actual["max_write_size"].get_value() == 8388608
         assert actual["system_time"].get_value() == datetime(
-            year=2017, month=11, day=16, hour=10, minute=6, second=17, microsecond=378946
+            year=2017,
+            month=11,
+            day=16,
+            hour=10,
+            minute=6,
+            second=17,
+            microsecond=378946,
+            tzinfo=timezone.utc,
         )
         assert actual["server_start_time"].get_value() == datetime(
-            year=2017, month=11, day=16, hour=10, minute=3, second=19, microsecond=927194
+            year=2017,
+            month=11,
+            day=16,
+            hour=10,
+            minute=3,
+            second=19,
+            microsecond=927194,
+            tzinfo=timezone.utc,
         )
         assert actual["security_buffer_offset"].get_value() == 128
         assert actual["security_buffer_length"].get_value() == 120
@@ -743,10 +757,24 @@ class TestSMB2NegotiateResponse:
         assert actual["max_read_size"].get_value() == 8388608
         assert actual["max_write_size"].get_value() == 8388608
         assert actual["system_time"].get_value() == datetime(
-            year=2017, month=11, day=15, hour=11, minute=32, second=12, microsecond=1616
+            year=2017,
+            month=11,
+            day=15,
+            hour=11,
+            minute=32,
+            second=12,
+            microsecond=1616,
+            tzinfo=timezone.utc,
         )
         assert actual["server_start_time"].get_value() == datetime(
-            year=2017, month=11, day=15, hour=11, minute=27, second=26, microsecond=349606
+            year=2017,
+            month=11,
+            day=15,
+            hour=11,
+            minute=27,
+            second=26,
+            microsecond=349606,
+            tzinfo=timezone.utc,
         )
         assert actual["security_buffer_offset"].get_value() == 128
         assert actual["security_buffer_length"].get_value() == 120

--- a/tests/test_create_contexts.py
+++ b/tests/test_create_contexts.py
@@ -3,7 +3,7 @@
 
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -450,7 +450,7 @@ class TestSMB2CreateDurableHandleReconnect:
 class TestSMB2CreateQueryMaximalAccessRequest:
     def test_create_message(self):
         message = SMB2CreateQueryMaximalAccessRequest()
-        message["timestamp"] = datetime.utcfromtimestamp(0)
+        message["timestamp"] = datetime.fromtimestamp(0, timezone.utc)
         expected = b"\x00\x80\x3e\xd5\xde\xb1\x9d\x01"
         actual = message.pack()
         assert len(message) == 8
@@ -462,7 +462,7 @@ class TestSMB2CreateQueryMaximalAccessRequest:
         data = actual.unpack(data)
         assert len(actual) == 8
         assert data == b""
-        assert actual["timestamp"].get_value() == datetime.utcfromtimestamp(0)
+        assert actual["timestamp"].get_value() == datetime.fromtimestamp(0, timezone.utc)
 
 
 class TestSMB2CreateQueryMaximalAccessResponse:
@@ -505,7 +505,7 @@ class TestSMB2CreateAllocationSize:
 class TestSMB2CreateTimewarpToken:
     def test_create_message(self):
         message = SMB2CreateTimewarpToken()
-        message["timestamp"] = datetime.utcfromtimestamp(0)
+        message["timestamp"] = datetime.fromtimestamp(0, timezone.utc)
         expected = b"\x00\x80\x3e\xd5\xde\xb1\x9d\x01"
         actual = message.pack()
         assert len(message) == 8
@@ -517,7 +517,7 @@ class TestSMB2CreateTimewarpToken:
         data = actual.unpack(data)
         assert len(actual) == 8
         assert data == b""
-        assert actual["timestamp"].get_value() == datetime.utcfromtimestamp(0)
+        assert actual["timestamp"].get_value() == datetime.fromtimestamp(0, timezone.utc)
 
 
 class TestSMB2CreateRequestLease:

--- a/tests/test_file_info.py
+++ b/tests/test_file_info.py
@@ -2,7 +2,7 @@
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from smbprotocol.file_info import (
     FileAllInformation,
@@ -135,10 +135,10 @@ class TestFileAllInformation:
 class TestFileBothDirectoryInformation:
     def test_create_message(self):
         message = FileBothDirectoryInformation()
-        message["creation_time"] = datetime.utcfromtimestamp(1024)
-        message["last_access_time"] = datetime.utcfromtimestamp(1024)
-        message["last_write_time"] = datetime.utcfromtimestamp(1024)
-        message["change_time"] = datetime.utcfromtimestamp(1024)
+        message["creation_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_access_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_write_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["change_time"] = datetime.fromtimestamp(1024, timezone.utc)
         message["end_of_file"] = 4
         message["allocation_size"] = 1048576
         message["file_attributes"] = 32
@@ -197,10 +197,10 @@ class TestFileBothDirectoryInformation:
         assert data == b""
         assert actual["next_entry_offset"].get_value() == 0
         assert actual["file_index"].get_value() == 0
-        assert actual["creation_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_access_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_write_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["change_time"].get_value() == datetime.utcfromtimestamp(1024)
+        assert actual["creation_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_access_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_write_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["change_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
         assert actual["end_of_file"].get_value() == 4
         assert actual["allocation_size"].get_value() == 1048576
         assert actual["file_attributes"].get_value() == 32
@@ -216,10 +216,10 @@ class TestFileBothDirectoryInformation:
 class TestFileDirectoryInformation:
     def test_create_message(self):
         message = FileDirectoryInformation()
-        message["creation_time"] = datetime.utcfromtimestamp(1024)
-        message["last_access_time"] = datetime.utcfromtimestamp(1024)
-        message["last_write_time"] = datetime.utcfromtimestamp(1024)
-        message["change_time"] = datetime.utcfromtimestamp(1024)
+        message["creation_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_access_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_write_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["change_time"] = datetime.fromtimestamp(1024, timezone.utc)
         message["end_of_file"] = 4
         message["allocation_size"] = 1048576
         message["file_attributes"] = 32
@@ -266,10 +266,10 @@ class TestFileDirectoryInformation:
         assert data == b""
         assert actual["next_entry_offset"].get_value() == 0
         assert actual["file_index"].get_value() == 0
-        assert actual["creation_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_access_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_write_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["change_time"].get_value() == datetime.utcfromtimestamp(1024)
+        assert actual["creation_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_access_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_write_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["change_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
         assert actual["end_of_file"].get_value() == 4
         assert actual["allocation_size"].get_value() == 1048576
         assert actual["file_attributes"].get_value() == 32
@@ -321,10 +321,10 @@ class TestFileEndOfFileInformation:
 class TestFileFullDirectoryInformation:
     def test_create_message(self):
         message = FileFullDirectoryInformation()
-        message["creation_time"] = datetime.utcfromtimestamp(1024)
-        message["last_access_time"] = datetime.utcfromtimestamp(1024)
-        message["last_write_time"] = datetime.utcfromtimestamp(1024)
-        message["change_time"] = datetime.utcfromtimestamp(1024)
+        message["creation_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_access_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_write_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["change_time"] = datetime.fromtimestamp(1024, timezone.utc)
         message["end_of_file"] = 4
         message["allocation_size"] = 1048576
         message["file_attributes"] = 32
@@ -373,10 +373,10 @@ class TestFileFullDirectoryInformation:
         assert data == b""
         assert actual["next_entry_offset"].get_value() == 0
         assert actual["file_index"].get_value() == 0
-        assert actual["creation_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_access_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_write_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["change_time"].get_value() == datetime.utcfromtimestamp(1024)
+        assert actual["creation_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_access_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_write_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["change_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
         assert actual["end_of_file"].get_value() == 4
         assert actual["allocation_size"].get_value() == 1048576
         assert actual["file_attributes"].get_value() == 32
@@ -442,10 +442,10 @@ class TestFileGetEaInformation:
 class TestFileIdBothDirectoryInformation:
     def test_create_message(self):
         message = FileIdBothDirectoryInformation()
-        message["creation_time"] = datetime.utcfromtimestamp(1024)
-        message["last_access_time"] = datetime.utcfromtimestamp(1024)
-        message["last_write_time"] = datetime.utcfromtimestamp(1024)
-        message["change_time"] = datetime.utcfromtimestamp(1024)
+        message["creation_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_access_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_write_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["change_time"] = datetime.fromtimestamp(1024, timezone.utc)
         message["end_of_file"] = 4
         message["allocation_size"] = 1048576
         message["file_attributes"] = 32
@@ -509,10 +509,10 @@ class TestFileIdBothDirectoryInformation:
         assert data == b""
         assert actual["next_entry_offset"].get_value() == 0
         assert actual["file_index"].get_value() == 0
-        assert actual["creation_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_access_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_write_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["change_time"].get_value() == datetime.utcfromtimestamp(1024)
+        assert actual["creation_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_access_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_write_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["change_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
         assert actual["end_of_file"].get_value() == 4
         assert actual["allocation_size"].get_value() == 1048576
         assert actual["file_attributes"].get_value() == 32
@@ -530,10 +530,10 @@ class TestFileIdBothDirectoryInformation:
 class TestFileIdFullDirectoryInformation:
     def test_create_message(self):
         message = FileIdFullDirectoryInformation()
-        message["creation_time"] = datetime.utcfromtimestamp(1024)
-        message["last_access_time"] = datetime.utcfromtimestamp(1024)
-        message["last_write_time"] = datetime.utcfromtimestamp(1024)
-        message["change_time"] = datetime.utcfromtimestamp(1024)
+        message["creation_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_access_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_write_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["change_time"] = datetime.fromtimestamp(1024, timezone.utc)
         message["end_of_file"] = 4
         message["allocation_size"] = 1048576
         message["file_attributes"] = 32
@@ -587,10 +587,10 @@ class TestFileIdFullDirectoryInformation:
         assert data == b""
         assert actual["next_entry_offset"].get_value() == 0
         assert actual["file_index"].get_value() == 0
-        assert actual["creation_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_access_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_write_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["change_time"].get_value() == datetime.utcfromtimestamp(1024)
+        assert actual["creation_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_access_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_write_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["change_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
         assert actual["end_of_file"].get_value() == 4
         assert actual["allocation_size"].get_value() == 1048576
         assert actual["file_attributes"].get_value() == 32
@@ -782,7 +782,7 @@ class TestFileFsVolumeInformation:
 
     def test_create_message(self):
         message = FileFsVolumeInformation()
-        message["volume_creation_time"] = datetime.utcfromtimestamp(0)
+        message["volume_creation_time"] = datetime.fromtimestamp(0, timezone.utc)
         message["volume_serial_number"] = 10
         message["volume_label"] = "café"
 
@@ -797,7 +797,7 @@ class TestFileFsVolumeInformation:
         assert len(actual) == 26
         assert data == b""
 
-        assert actual["volume_creation_time"].get_value() == datetime.utcfromtimestamp(0)
+        assert actual["volume_creation_time"].get_value() == datetime.fromtimestamp(0, timezone.utc)
         assert actual["volume_serial_number"].get_value() == 10
         assert actual["volume_label_length"].get_value() == 8
         assert actual["supports_objects"].get_value() is False

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -4,7 +4,7 @@
 import os
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -70,7 +70,7 @@ from smbprotocol.tree import TreeConnect
 class TestSMB2CreateRequest:
     def test_create_message(self):
         timewarp_token = SMB2CreateTimewarpToken()
-        timewarp_token["timestamp"] = datetime.utcfromtimestamp(0)
+        timewarp_token["timestamp"] = datetime.fromtimestamp(0, timezone.utc)
         timewarp_context = SMB2CreateContextRequest()
         timewarp_context["buffer_name"] = CreateContextName.SMB2_CREATE_TIMEWARP_TOKEN
         timewarp_context["buffer_data"] = timewarp_token
@@ -272,17 +272,17 @@ class TestSMB2CreateResponse:
         message = SMB2CreateResponse()
         message["flag"] = FileFlags.SMB2_CREATE_FLAG_REPARSEPOINT
         message["create_action"] = CreateAction.FILE_CREATED
-        message["creation_time"] = datetime.utcfromtimestamp(1024)
-        message["last_access_time"] = datetime.utcfromtimestamp(2048)
-        message["last_write_time"] = datetime.utcfromtimestamp(3072)
-        message["change_time"] = datetime.utcfromtimestamp(4096)
+        message["creation_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_access_time"] = datetime.fromtimestamp(2048, timezone.utc)
+        message["last_write_time"] = datetime.fromtimestamp(3072, timezone.utc)
+        message["change_time"] = datetime.fromtimestamp(4096, timezone.utc)
         message["allocation_size"] = 10
         message["end_of_file"] = 20
         message["file_attributes"] = FileAttributes.FILE_ATTRIBUTE_ARCHIVE
         message["file_id"] = b"\xff" * 16
 
         timewarp_token = SMB2CreateTimewarpToken()
-        timewarp_token["timestamp"] = datetime.utcfromtimestamp(0)
+        timewarp_token["timestamp"] = datetime.fromtimestamp(0, timezone.utc)
         timewarp_context = SMB2CreateContextRequest()
         timewarp_context["buffer_name"] = CreateContextName.SMB2_CREATE_TIMEWARP_TOKEN
         timewarp_context["buffer_data"] = timewarp_token
@@ -322,10 +322,10 @@ class TestSMB2CreateResponse:
         message = SMB2CreateResponse()
         message["flag"] = FileFlags.SMB2_CREATE_FLAG_REPARSEPOINT
         message["create_action"] = CreateAction.FILE_CREATED
-        message["creation_time"] = datetime.utcfromtimestamp(1024)
-        message["last_access_time"] = datetime.utcfromtimestamp(2048)
-        message["last_write_time"] = datetime.utcfromtimestamp(3072)
-        message["change_time"] = datetime.utcfromtimestamp(4096)
+        message["creation_time"] = datetime.fromtimestamp(1024, timezone.utc)
+        message["last_access_time"] = datetime.fromtimestamp(2048, timezone.utc)
+        message["last_write_time"] = datetime.fromtimestamp(3072, timezone.utc)
+        message["change_time"] = datetime.fromtimestamp(4096, timezone.utc)
         message["allocation_size"] = 10
         message["end_of_file"] = 20
         message["file_attributes"] = FileAttributes.FILE_ATTRIBUTE_ARCHIVE
@@ -388,10 +388,10 @@ class TestSMB2CreateResponse:
         assert actual["oplock_level"].get_value() == 0
         assert actual["flag"].get_value() == FileFlags.SMB2_CREATE_FLAG_REPARSEPOINT
         assert actual["create_action"].get_value() == CreateAction.FILE_CREATED
-        assert actual["creation_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_access_time"].get_value() == datetime.utcfromtimestamp(2048)
-        assert actual["last_write_time"].get_value() == datetime.utcfromtimestamp(3072)
-        assert actual["change_time"].get_value() == datetime.utcfromtimestamp(4096)
+        assert actual["creation_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_access_time"].get_value() == datetime.fromtimestamp(2048, timezone.utc)
+        assert actual["last_write_time"].get_value() == datetime.fromtimestamp(3072, timezone.utc)
+        assert actual["change_time"].get_value() == datetime.fromtimestamp(4096, timezone.utc)
         assert actual["allocation_size"].get_value() == 10
         assert actual["end_of_file"].get_value() == 20
         assert actual["file_attributes"].get_value() == FileAttributes.FILE_ATTRIBUTE_ARCHIVE
@@ -441,10 +441,10 @@ class TestSMB2CreateResponse:
         assert actual["oplock_level"].get_value() == 0
         assert actual["flag"].get_value() == FileFlags.SMB2_CREATE_FLAG_REPARSEPOINT
         assert actual["create_action"].get_value() == CreateAction.FILE_CREATED
-        assert actual["creation_time"].get_value() == datetime.utcfromtimestamp(1024)
-        assert actual["last_access_time"].get_value() == datetime.utcfromtimestamp(2048)
-        assert actual["last_write_time"].get_value() == datetime.utcfromtimestamp(3072)
-        assert actual["change_time"].get_value() == datetime.utcfromtimestamp(4096)
+        assert actual["creation_time"].get_value() == datetime.fromtimestamp(1024, timezone.utc)
+        assert actual["last_access_time"].get_value() == datetime.fromtimestamp(2048, timezone.utc)
+        assert actual["last_write_time"].get_value() == datetime.fromtimestamp(3072, timezone.utc)
+        assert actual["change_time"].get_value() == datetime.fromtimestamp(4096, timezone.utc)
         assert actual["allocation_size"].get_value() == 10
         assert actual["end_of_file"].get_value() == 20
         assert actual["file_attributes"].get_value() == FileAttributes.FILE_ATTRIBUTE_ARCHIVE
@@ -491,10 +491,10 @@ class TestSMB2CloseRequest:
 class TestSMB2CloseResponse:
     def test_create_message(self):
         message = SMB2CloseResponse()
-        message["creation_time"] = datetime.utcfromtimestamp(0)
-        message["last_access_time"] = datetime.utcfromtimestamp(0)
-        message["last_write_time"] = datetime.utcfromtimestamp(0)
-        message["change_time"] = datetime.utcfromtimestamp(0)
+        message["creation_time"] = datetime.fromtimestamp(0, timezone.utc)
+        message["last_access_time"] = datetime.fromtimestamp(0, timezone.utc)
+        message["last_write_time"] = datetime.fromtimestamp(0, timezone.utc)
+        message["change_time"] = datetime.fromtimestamp(0, timezone.utc)
         expected = (
             b"\x3c\x00"
             b"\x00\x00"
@@ -530,10 +530,10 @@ class TestSMB2CloseResponse:
         assert actual["structure_size"].get_value() == 60
         assert actual["flags"].get_value() == 0
         assert actual["reserved"].get_value() == 0
-        assert actual["creation_time"].get_value() == datetime.utcfromtimestamp(0)
-        assert actual["last_access_time"].get_value() == datetime.utcfromtimestamp(0)
-        assert actual["last_write_time"].get_value() == datetime.utcfromtimestamp(0)
-        assert actual["change_time"].get_value() == datetime.utcfromtimestamp(0)
+        assert actual["creation_time"].get_value() == datetime.fromtimestamp(0, timezone.utc)
+        assert actual["last_access_time"].get_value() == datetime.fromtimestamp(0, timezone.utc)
+        assert actual["last_write_time"].get_value() == datetime.fromtimestamp(0, timezone.utc)
+        assert actual["change_time"].get_value() == datetime.fromtimestamp(0, timezone.utc)
         assert actual["allocation_size"].get_value() == 0
         assert actual["end_of_file"].get_value() == 0
         assert actual["file_attributes"].get_value() == 0

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -4,7 +4,7 @@
 import types
 import uuid
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -1044,7 +1044,11 @@ class TestDateTimeField:
     @pytest.mark.parametrize(
         "raw, expected_dt, expected_bytes",
         [
-            (b"\x00\x00\x00\x00\x00\x00\x00\x00", datetime(1601, 1, 1, 0, 0, 0), b"\x00\x00\x00\x00\x00\x00\x00\x00"),
+            (
+                b"\x00\x00\x00\x00\x00\x00\x00\x00",
+                datetime(1601, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                b"\x00\x00\x00\x00\x00\x00\x00\x00",
+            ),
             (
                 b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",
                 datetime(9999, 12, 31, 23, 59, 59, 999999),
@@ -1091,7 +1095,16 @@ class TestDateTimeField:
     def test_unpack(self):
         field = self.StructureTest()["field"]
         field.unpack(b"\x5e\x70\x27\x4a\x6e\x23\x93\x01")
-        expected = datetime(year=1960, month=8, day=1, hour=22, minute=7, second=1, microsecond=186774)
+        expected = datetime(
+            year=1960,
+            month=8,
+            day=1,
+            hour=22,
+            minute=7,
+            second=1,
+            microsecond=186774,
+            tzinfo=timezone.utc,
+        )
         actual = field.get_value()
         assert actual == expected
 
@@ -1110,8 +1123,28 @@ class TestDateTimeField:
         field = structure["field"]
         field.name = "field"
         field.structure = self.StructureTest
-        field.set_value(lambda s: datetime(year=1960, month=8, day=2, hour=8, minute=7, second=1, microsecond=186774))
-        expected = datetime(year=1960, month=8, day=2, hour=8, minute=7, second=1, microsecond=186774)
+        field.set_value(
+            lambda s: datetime(
+                year=1960,
+                month=8,
+                day=2,
+                hour=8,
+                minute=7,
+                second=1,
+                microsecond=186774,
+                tzinfo=timezone.utc,
+            )
+        )
+        expected = datetime(
+            year=1960,
+            month=8,
+            day=2,
+            hour=8,
+            minute=7,
+            second=1,
+            microsecond=186774,
+            tzinfo=timezone.utc,
+        )
         actual = field.get_value()
         assert isinstance(field.value, types.LambdaType)
         assert actual == expected
@@ -1120,7 +1153,15 @@ class TestDateTimeField:
     def test_set_bytes(self):
         field = self.StructureTest()["field"]
         field.set_value(b"\x00\x67\x7b\x21\x3d\x5d\xd3\x01")
-        expected = datetime(year=2017, month=11, day=14, hour=11, minute=38, second=46)
+        expected = datetime(
+            year=2017,
+            month=11,
+            day=14,
+            hour=11,
+            minute=38,
+            second=46,
+            tzinfo=timezone.utc,
+        )
         actual = field.get_value()
         assert isinstance(field.value, datetime)
         assert actual == expected
@@ -1128,7 +1169,15 @@ class TestDateTimeField:
     def test_set_int(self):
         field = self.StructureTest()["field"]
         field.set_value(131551331260000000)
-        expected = datetime(year=2017, month=11, day=14, hour=11, minute=38, second=46)
+        expected = datetime(
+            year=2017,
+            month=11,
+            day=14,
+            hour=11,
+            minute=38,
+            second=46,
+            tzinfo=timezone.utc,
+        )
         actual = field.get_value()
         assert isinstance(field.value, datetime)
         assert actual == expected


### PR DESCRIPTION
Stop using a deprecated function that was deprecated in Python 3.12 and ensure any datetime values unpacked from SMB messages are using the UTC timezone instead of being a naive tz.