### PR TITLE
More advanced DFS compatibility checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * This avoid having to call `stat()` to retrieve data like the file attributes or datetime fields that is already available
 * Ensure `DateTimeField` values are set to `UTC` timezones as FILETIME values are in UTC
 * Stop using `datetime.datetime.utcfromtimestamp()` as it has been deprecated
+* Avoid setting DFS request when the server does not report it is capable of DFS operations.
 
 ## 1.12.0 - 2023-11-09
 

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -1198,7 +1198,7 @@ class Connection:
             if tree_id not in session.tree_connect_table:
                 raise SMBException("Cannot find Tree with the ID %d in the session tree table" % tree_id)
             tree = session.tree_connect_table[tree_id]
-            is_dfs = tree.is_dfs_share
+            is_dfs = self.server_capabilities.has_flag(Capabilities.SMB2_GLOBAL_CAP_DFS) and tree.is_dfs_share
 
         total_requests = len(messages)
         for i, message in enumerate(messages):


### PR DESCRIPTION
Avoid setting the SMB2_FLAGS_DFS_OPERATIONS flag in the SMB header if the server did not report it as supporting DFS operations during the negotiation phase. This should hopefully fix up some problems when the server errors in the case it doesn't support DFS operations.

Fixes: https://github.com/jborean93/smbprotocol/issues/242