### PR TITLE
Added default timeout on connection.receive()

### DIFF
--- a/src/smbclient/_pool.py
+++ b/src/smbclient/_pool.py
@@ -210,7 +210,7 @@ def dfs_request(tree: TreeConnect, path: str) -> DFSReferralResponse:
     return dfs_response
 
 
-def delete_session(server, port=445, connection_cache=None):
+def delete_session(server, port=445, connection_cache=None, timeout=60):
     """
     Deletes the connection in the connection pool for the server specified. This will also close all sessions
     associated with the connection.
@@ -226,7 +226,7 @@ def delete_session(server, port=445, connection_cache=None):
     connection = connection_cache.get(connection_key, None)
     if connection:
         del connection_cache[connection_key]
-        connection.disconnect(close=True)
+        connection.disconnect(close=True, timeout=timeout)
 
 
 def get_smb_tree(

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -989,7 +989,7 @@ class Connection:
         """
         return self._send(messages, session_id=sid, tree_id=tid, related=related)
 
-    def receive(self, request, wait=True, timeout=None, resolve_symlinks=True):
+    def receive(self, request, wait=True, timeout=60, resolve_symlinks=True):
         """
         Polls the message buffer of the TCP connection and waits until a valid
         message is received based on the message_id passed in.

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -989,7 +989,7 @@ class Connection:
         """
         return self._send(messages, session_id=sid, tree_id=tid, related=related)
 
-    def receive(self, request, wait=True, timeout=60, resolve_symlinks=True):
+    def receive(self, request, wait=True, timeout=None, resolve_symlinks=True):
         """
         Polls the message buffer of the TCP connection and waits until a valid
         message is received based on the message_id passed in.

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -931,7 +931,7 @@ class Connection:
                 elif context_type == NegotiateContextType.SMB2_SIGNING_CAPABILITIES:
                     self.signing_algorithm_id = context["data"]["signing_algorithms"][0]
 
-    def disconnect(self, close=True):
+    def disconnect(self, close=True, timeout=None):
         """
         Closes the connection as well as logs off any of the
         Disconnects the TCP connection and shuts down the socket listener
@@ -943,7 +943,7 @@ class Connection:
         # We cannot close the session or tree if the socket has been closed.
         if close and self.transport.connected:
             for session in list(self.session_table.values()):
-                session.disconnect(True)
+                session.disconnect(True, timeout=timeout)
 
         log.info("Disconnecting transport connection")
         self.transport.close()

--- a/src/smbprotocol/session.py
+++ b/src/smbprotocol/session.py
@@ -394,7 +394,7 @@ class Session:
             log.info("Verifying the SMB Setup Session signature as auth is successful")
             self.connection.verify_signature(response, self.session_id, force=True)
 
-    def disconnect(self, close=True):
+    def disconnect(self, close=True, timeout=None):
         """
         Logs off the session
 
@@ -418,7 +418,7 @@ class Session:
         request = self.connection.send(logoff, sid=self.session_id)
 
         log.info("Session: %s - Receiving Logoff response", self.username)
-        res = self.connection.receive(request)
+        res = self.connection.receive(request, timeout=timeout)
         res_logoff = SMB2Logoff()
         res_logoff.unpack(res["data"].get_value())
         log.debug(res_logoff)


### PR DESCRIPTION
The library hang when following these steps:
 - Connect using register_connection() to a SMB server.
 - Shut down the server, using the normal shutdown procedure.
 - Call any kind of disconnect(), like reset_connection_cache()
Now the library hangs.

This is because of the connection.receive() function is called against a dead server, without a timeout.

This pull request suggests setting the default timeout of the connection.receive() function to the same value as the default timeout of the other functions.