### PR TITLE
Wait for message thread to stop on disconnect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Ensure `DateTimeField` values are set to `UTC` timezones as FILETIME values are in UTC
 * Stop using `datetime.datetime.utcfromtimestamp()` as it has been deprecated
 * Added default timeout for disconnect operations for 60 seconds to ensure the process doesn't hang forever when closing a broken connection
+* `smbprotocol.connection.Connection.disconnect()` now waits (with a timeout) for the message processing threads to be stopped before returning.
 
 ## 1.12.0 - 2023-11-09
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ To this module, you need to install some pre-requisites first. This can be done
 by running;
 
 ```bash
+# Install in current virtual environment.
 pip install -r requirements-dev.txt
+pip install -e .
 
 # you can also run tox by installing tox
 pip install tox
@@ -231,9 +233,9 @@ pip install tox
 From there to run the basic tests run;
 
 ```bash
-py.test -v --pep8 --cov smbprotocol --cov-report term-missing
+py.test -v --cov smbprotocol --cov-report term-missing
 
-# or with tox 2.7, 2.7, 3.4, 3.5, and 3.6
+# or with tox for dedicated virtual environments and multiple Python versions.
 tox
 ```
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ To this module, you need to install some pre-requisites first. This can be done
 by running;
 
 ```bash
-# Install in current virtual environment.
+# Install in current environment.
+# Recommend to have virtual environment installed at .venv path.
 pip install -r requirements-dev.txt
 pip install -e .
 
@@ -237,6 +238,15 @@ py.test -v --cov smbprotocol --cov-report term-missing
 
 # or with tox for dedicated virtual environments and multiple Python versions.
 tox
+```
+
+Before sending the code for review, besides making sure all the test pass,
+check that the code complies with the coding standards:
+
+```bash
+source ./build_helpers/lib.sh
+
+lib::sanity::run
 ```
 
 There are extra tests that only run when certain environment variables are set.

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -861,11 +861,11 @@ class Connection:
         log.info("Setting up transport connection")
         self.transport = Tcp(self.server_name, self.port, timeout)
         self.transport.connect()
-        t_worker = threading.Thread(
+        self._t_worker = threading.Thread(
             target=self._process_message_thread, name=f"msg_worker-{self.server_name}:{self.port}"
         )
-        t_worker.daemon = True
-        t_worker.start()
+        self._t_worker.daemon = True
+        self._t_worker.start()
 
         log.info("Starting negotiation with SMB server")
         enc_algos = preferred_encryption_algos or [
@@ -947,6 +947,7 @@ class Connection:
 
         log.info("Disconnecting transport connection")
         self.transport.close()
+        self._t_worker.join(timeout=2)
 
     def send(
         self, message, sid=None, tid=None, credit_request=None, message_id=None, async_id=None, force_signature=False

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -820,6 +820,9 @@ class Connection:
         # Keep track of the message processing thread's potential traceback that it may raise.
         self._t_exc = None
 
+        # The thread that will handle message processing.
+        self._t_worker = None
+
     def connect(self, dialect=None, timeout=60, preferred_encryption_algos=None, preferred_signing_algos=None):
         """
         Will connect to the target server and negotiate the capabilities

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -947,7 +947,8 @@ class Connection:
 
         log.info("Disconnecting transport connection")
         self.transport.close()
-        self._t_worker.join(timeout=2)
+        if self._t_worker:
+            self._t_worker.join(timeout=2)
 
     def send(
         self, message, sid=None, tid=None, credit_request=None, message_id=None, async_id=None, force_signature=False

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1306,8 +1306,7 @@ class TestConnection:
         """
         connection, session = connected_session
 
-        actual = connection.echo(
-            sid=session.session_id, credit_request=65535)
+        actual = connection.echo(sid=session.session_id, credit_request=65535)
 
         assert actual == 8129
 
@@ -1317,7 +1316,7 @@ class TestConnection:
         allocated credits.
         """
         connection, _ = connected_session
-        msg_thread = f'msg_worker-{connection.server_name}:{connection.port}'
+        msg_thread = f"msg_worker-{connection.server_name}:{connection.port}"
 
         current_threads = [t.name for t in threading.enumerate()]
         assert msg_thread in current_threads

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1312,8 +1312,7 @@ class TestConnection:
 
     def test_disconnect_wait_for_thread(self, connected_session):
         """
-        When requesting more credit from the server, it will return the
-        allocated credits.
+        Disconnect will continue after the message thread is stopped.
         """
         connection, _ = connected_session
         msg_thread = f"msg_worker-{connection.server_name}:{connection.port}"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,6 +2,7 @@
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
 import os
+import threading
 import uuid
 from datetime import datetime, timezone
 
@@ -32,6 +33,22 @@ from smbprotocol.exceptions import SMBConnectionClosed, SMBException
 from smbprotocol.header import Smb2Flags, SMB2HeaderResponse
 from smbprotocol.ioctl import SMB2IOCTLRequest
 from smbprotocol.session import Session
+
+
+@pytest.fixture
+def connected_session(smb_real):
+    """
+    Return a (connection, session) tuple that is already connected to the
+    SMB server and that will disconnect at the end.
+    """
+    connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
+    connection.connect()
+    session = Session(connection, smb_real[0], smb_real[1])
+    session.connect()
+
+    yield connection, session
+
+    connection.disconnect(True)
 
 
 class TestSMB2NegotiateRequest:
@@ -1183,6 +1200,9 @@ class TestConnection:
             connection.disconnect()
 
     def test_connection_echo(self, smb_real):
+        """
+        SMB2 Echo can be used to request extra credits from the server.
+        """
         connection = Connection(uuid.uuid4(), smb_real[2], smb_real[3])
         connection.connect()
         session = Session(connection, smb_real[0], smb_real[1])
@@ -1278,3 +1298,41 @@ class TestConnection:
         actual = connection._encrypt(b"\x01\x02\x03\x04", session)
         assert isinstance(actual, SMB2TransformHeader)
         assert actual.pack() == expected.pack()
+
+    def test_connection_echo_more(self, connected_session):
+        """
+        When requesting more credit from the server, it will return the
+        allocated credits.
+        """
+        connection, session = connected_session
+
+        actual = connection.echo(
+            sid=session.session_id, credit_request=65535)
+
+        assert actual == 8129
+
+    def test_disconnect_wait_for_thread(self, connected_session):
+        """
+        When requesting more credit from the server, it will return the
+        allocated credits.
+        """
+        connection, _ = connected_session
+        msg_thread = f'msg_worker-{connection.server_name}:{connection.port}'
+
+        current_threads = [t.name for t in threading.enumerate()]
+        assert msg_thread in current_threads
+
+        connection.disconnect()
+
+        current_threads = [t.name for t in threading.enumerate()]
+        assert msg_thread not in current_threads
+
+    def test_disconnect_already_disconnected(self, connected_session):
+        """
+        Disconnect can be called multiple times, and is a noop if
+        already disconnected.
+        """
+        connection, _ = connected_session
+
+        connection.disconnect()
+        connection.disconnect()


### PR DESCRIPTION
## Scope

Fixes #254 

This is mostly to help with autoamted tests.


## Changes

On disconnect wait a bit for the thread.

If the thread is still running, disconect will still return, just like before.

I have created a fixte to reduce the duplicate code required to setup a connection and all the try/finally for cleanup.

As as drive-by I have updated the docstring for echo test and wrote another test for echo, as I was using those tests to learn about testing code.

As a drive by, I have updated the README with some info a found during initial dev.
Feel free to revert those changes.