### PR TITLE
Shutil.copyfile will open source with read share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added default timeout for disconnect operations for 60 seconds to ensure the process doesn't hang forever when closing a broken connection
 * `smbprotocol.connection.Connection.disconnect()` now waits (with a timeout) for the message processing threads to be stopped before returning.
 * Do not set the SMB SessionId and TreeId in the headers to `0xFFFFFFFF` for related compound requests
++ Ensures the source file for `shutil.copyfile` is opened with `share_access="r"` for better compatibility with files already opened by something else
 
 ## 1.12.0 - 2023-11-09
 

--- a/tests/test_smbclient_shutil.py
+++ b/tests/test_smbclient_shutil.py
@@ -4,6 +4,7 @@
 import ctypes
 import ntpath
 import os
+import os.path
 import re
 import shutil
 import stat
@@ -299,6 +300,23 @@ def test_copyfile_remote_to_local(smb_share, tmpdir):
         fd.write("content")
 
     actual = copyfile(src_filename, dst_filename)
+    assert actual == dst_filename
+
+    with open(dst_filename) as fd:
+        assert fd.read() == "content"
+
+
+def test_copyfile_remote_to_local_read_share(smb_share, tmpdir):
+    test_dir = tmpdir.mkdir("test")
+    src_filename = "%s\\source.txt" % smb_share
+    dst_filename = os.path.join(test_dir, "target.txt")
+
+    with open_file(src_filename, mode="w") as fd:
+        fd.write("content")
+
+    with open_file(src_filename, mode="r", share_access="r") as fd:
+        actual = copyfile(src_filename, dst_filename)
+
     assert actual == dst_filename
 
     with open(dst_filename) as fd:


### PR DESCRIPTION
Opens the source file used in shutil.copyfile with share_access="r" to ensure that it can be copied even if something else already has it opened with read access and grants further opens.

Fixes: https://github.com/jborean93/smbprotocol/issues/258