### PR TITLE
Fix up compound request session and tree ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Stop using `datetime.datetime.utcfromtimestamp()` as it has been deprecated
 * Added default timeout for disconnect operations for 60 seconds to ensure the process doesn't hang forever when closing a broken connection
 * `smbprotocol.connection.Connection.disconnect()` now waits (with a timeout) for the message processing threads to be stopped before returning.
+* Do not set the SMB SessionId and TreeId in the headers to `0xFFFFFFFF` for related compound requests
 
 ## 1.12.0 - 2023-11-09
 

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -1256,8 +1256,6 @@ class Connection:
                 header["flags"].set_flag(Smb2Flags.SMB2_FLAGS_DFS_OPERATIONS)
 
             if i != 0 and related:
-                header["session_id"] = b"\xff" * 8
-                header["tree_id"] = b"\xff" * 4
                 header["flags"].set_flag(Smb2Flags.SMB2_FLAGS_RELATED_OPERATIONS)
 
             if force_signature or (session and session.signing_required and session.signing_key):


### PR DESCRIPTION
Change to not set the SessionId and TreeId in the SMB headers of related compound requests as it is not in the spec. The spec only states the FileId used in the first create should be set to all bits and not these other two fields.

Fixes: https://github.com/jborean93/smbprotocol/issues/260