### PR TITLE
Fix up endless auth loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `smbprotocol.connection.Connection.disconnect()` now waits (with a timeout) for the message processing threads to be stopped before returning.
 * Do not set the SMB SessionId and TreeId in the headers to `0xFFFFFFFF` for related compound requests
 + Ensures the source file for `shutil.copyfile` is opened with `share_access="r"` for better compatibility with files already opened by something else
++ Remove endless authentication loop when the context is complete and no more input messages are needed
 
 ## 1.12.0 - 2023-11-09
 

--- a/src/smbprotocol/session.py
+++ b/src/smbprotocol/session.py
@@ -277,7 +277,7 @@ class Session:
         if self.auth_protocol != "negotiate":
             in_token = None  # The GSS Negotiate Token can only be used for Negotiate auth.
 
-        while not context.complete or in_token:
+        while not context.complete:
             try:
                 out_token = context.step(in_token)
             except spnego.exceptions.SpnegoError as err:


### PR DESCRIPTION
Fix up the endless loop that can occur during authentication when the authentication context was complete but the server still continued to respond with an access token. This should not happen with any major server but still possible with some more niche implementations like impacket.

Fixes: https://github.com/jborean93/smbprotocol/issues/261