### PR TITLE
Bump version and update dev deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,9 @@ jobs:
     - name: Extract OS name
       shell: bash
       run: |
-        echo NAME=$( echo '${{ matrix.os }}' | tr '-' ' ' | awk '{print $1}' )
-        echo "name=${NAME}" >> $GITHUB_OUTPUT
+        NAME=$( echo '${{ matrix.os }}' | tr '-' ' ' | awk '{print $1}' )
+        echo "${NAME}"
+        echo "name=${NAME}" >> "${GITHUB_OUTPUT}"
       id: os
 
     - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build smbprotocol
       run: |
@@ -35,7 +35,7 @@ jobs:
         python -m build
 
     - name: Upload built smbprotocol
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: artifact
         path: ./dist/*
@@ -55,7 +55,6 @@ jobs:
         - windows-2019
         - windows-2022
         python-version:
-        - 3.7
         - 3.8
         - 3.9
         - '3.10'
@@ -73,8 +72,6 @@ jobs:
         - os: windows-2019
           python-arch: x86
         - os: windows-2019
-          python-version: 3.7
-        - os: windows-2019
           python-version: 3.8
         - os: windows-2019
           python-version: 3.9
@@ -84,14 +81,14 @@ jobs:
           python-version: '3.12'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-arch }}
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: ./dist
@@ -116,24 +113,25 @@ jobs:
 
     - name: Upload Test Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Unit Test Results (${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.python-arch }})
         path: ./junit/test-results.xml
 
     - name: Upload Coverage Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Coverage Results (${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.python-arch }})
         path: ./coverage.xml
 
     - name: Upload Coverage to codecov
       if: always()
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml
         flags: ${{ steps.os.outputs.name }},py${{ matrix.python-version }},${{ matrix.python-arch }}
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     name: publish
@@ -145,7 +143,7 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: ./dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 24.3.0
   hooks:
   - id: black
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.5
+  rev: 5.13.2
   hooks:
   - id: isort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.14.0 - TBD
+
+* Dropped support for Python 3.7
+
 ## 1.13.0 - 2024-03-21
 
 * Added the property `smb_info` on `SMBDirEntry` which returns a named tuple `SMBDirEntryInformation` containing metadata already retrieved in the `scandir` operation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smbprotocol"
-version = "1.13.0"
+version = "1.14.0"
 description = "Interact with a server using the SMB 2/3 Protocol"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [
     { name = "Jordan Borean", email = "jborean93@gmail.com" }
@@ -19,7 +19,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -67,7 +66,7 @@ addopts = "--import-mode=importlib"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = sanity,py37,py38,py39,py310,py311
+envlist = sanity,py38,py39,py310,py311,py312
 skip_missing_interpreters = true
 isolated_build = true
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-black == 23.3.0
+black == 24.3.0
 build
 cryptography >= 2.0
-isort == 5.11.5
+isort == 5.13.2
 pre-commit
 pyspnego
 pytest


### PR DESCRIPTION
Bumps the version after the last release and update the dev dependencies to reflect the latest version available today. This commit also drops Python 3.7 as it has been EOL for a few months now and some dev dependencies no longer work on 3.7.