### PR TITLE
Customizable receive timeout for SMB Connection

### DIFF
--- a/src/smbclient/_pool.py
+++ b/src/smbclient/_pool.py
@@ -230,7 +230,7 @@ def delete_session(server, port=445, connection_cache=None, timeout=60):
 
 
 def get_smb_tree(
-    path, username=None, password=None, port=445, encrypt=None, connection_timeout=60, connection_cache=None
+    path, username=None, password=None, port=445, encrypt=None, receive_timeout=600, connection_timeout=60, connection_cache=None,
 ):
     """
     Returns an active Tree connection and file path including the tree based on the UNC path passed in and other
@@ -244,6 +244,7 @@ def get_smb_tree(
     :param port: The port to connect with.
     :param encrypt: Whether to force encryption or not, once this has been set to True the session cannot be changed
         back to False.
+    :param receive_timeout: Override the timeout used for receiving a response from the server
     :param connection_timeout: Override the timeout used for the initial connection.
     :param connection_cache: Connection cache to be used with
     :return: The TreeConnect and file path including the tree based on the UNC path passed in.
@@ -261,6 +262,7 @@ def get_smb_tree(
         "password": password,
         "port": port,
         "encrypt": encrypt,
+        "receive_timeout": receive_timeout,
         "connection_timeout": connection_timeout,
         "connection_cache": connection_cache,
     }
@@ -307,6 +309,7 @@ def get_smb_tree(
         password=password,
         port=port,
         encrypt=encrypt,
+        receive_timeout=receive_timeout,
         connection_timeout=connection_timeout,
         connection_cache=connection_cache,
         auth_protocol=auth_protocol,
@@ -371,6 +374,7 @@ def register_session(
     password=None,
     port=445,
     encrypt=None,
+    receive_timeout=600,
     connection_timeout=60,
     connection_cache=None,
     auth_protocol="negotiate",
@@ -389,6 +393,7 @@ def register_session(
     :param port: The port to connect with. Defaults to 445.
     :param encrypt: Whether to force encryption or not, once this has been set to True the session cannot be changed
         back to False.
+    :param receive_timeout: Override the timeout used for receiving a response from the server
     :param connection_timeout: Override the timeout used for the initial connection.
     :param connection_cache: Connection cache to be used with
     :param auth_protocol: The protocol to use for authentication. Possible values are 'negotiate', 'ntlm' or
@@ -405,6 +410,7 @@ def register_session(
     # Make sure we ignore any connections that may have had a closed connection
     if not connection or not connection.transport.connected:
         connection = Connection(ClientConfig().client_guid, server, port, require_signing=require_signing)
+        connection.receive_timeout = receive_timeout
         connection.connect(timeout=connection_timeout)
         connection_cache[connection_key] = connection
 

--- a/src/smbclient/_pool.py
+++ b/src/smbclient/_pool.py
@@ -230,7 +230,7 @@ def delete_session(server, port=445, connection_cache=None, timeout=60):
 
 
 def get_smb_tree(
-    path, username=None, password=None, port=445, encrypt=None, receive_timeout=600, connection_timeout=60, connection_cache=None,
+    path, username=None, password=None, port=445, encrypt=None, connection_timeout=60, connection_cache=None
 ):
     """
     Returns an active Tree connection and file path including the tree based on the UNC path passed in and other
@@ -244,7 +244,6 @@ def get_smb_tree(
     :param port: The port to connect with.
     :param encrypt: Whether to force encryption or not, once this has been set to True the session cannot be changed
         back to False.
-    :param receive_timeout: Override the timeout used for receiving a response from the server
     :param connection_timeout: Override the timeout used for the initial connection.
     :param connection_cache: Connection cache to be used with
     :return: The TreeConnect and file path including the tree based on the UNC path passed in.
@@ -262,7 +261,6 @@ def get_smb_tree(
         "password": password,
         "port": port,
         "encrypt": encrypt,
-        "receive_timeout": receive_timeout,
         "connection_timeout": connection_timeout,
         "connection_cache": connection_cache,
     }
@@ -309,7 +307,6 @@ def get_smb_tree(
         password=password,
         port=port,
         encrypt=encrypt,
-        receive_timeout=receive_timeout,
         connection_timeout=connection_timeout,
         connection_cache=connection_cache,
         auth_protocol=auth_protocol,
@@ -374,7 +371,6 @@ def register_session(
     password=None,
     port=445,
     encrypt=None,
-    receive_timeout=600,
     connection_timeout=60,
     connection_cache=None,
     auth_protocol="negotiate",
@@ -393,7 +389,6 @@ def register_session(
     :param port: The port to connect with. Defaults to 445.
     :param encrypt: Whether to force encryption or not, once this has been set to True the session cannot be changed
         back to False.
-    :param receive_timeout: Override the timeout used for receiving a response from the server
     :param connection_timeout: Override the timeout used for the initial connection.
     :param connection_cache: Connection cache to be used with
     :param auth_protocol: The protocol to use for authentication. Possible values are 'negotiate', 'ntlm' or
@@ -410,7 +405,6 @@ def register_session(
     # Make sure we ignore any connections that may have had a closed connection
     if not connection or not connection.transport.connected:
         connection = Connection(ClientConfig().client_guid, server, port, require_signing=require_signing)
-        connection.receive_timeout = receive_timeout
         connection.connect(timeout=connection_timeout)
         connection_cache[connection_key] = connection
 

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -749,7 +749,8 @@ class Connection:
         self.port = port
         self.transport = None  # Instanciated in .connect()
 
-        self.receive_timeout = 600
+        # Experimental customizable value. Might be removed in the future
+        self._receive_timeout = int(os.environ.get("SMB_EXPERIMENTAL_TRANSPORT_RECEIVE_TIMEOUT", 600))
 
         # Table of Session entries, the order is important for smbclient.
         self.session_table = OrderedDict()
@@ -1308,7 +1309,7 @@ class Connection:
                 # safe choice.
                 # https://github.com/jborean93/smbprotocol/issues/31
                 try:
-                    b_msg = self.transport.recv(self.receive_timeout)
+                    b_msg = self.transport.recv(self._receive_timeout)
                 except TimeoutError as ex:
                     # Check if the connection has unanswered keepalive echo requests with the reserved field set.
                     # When unanswered keep alive echo exists, the server did not respond withing two times the timeout.

--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -749,6 +749,8 @@ class Connection:
         self.port = port
         self.transport = None  # Instanciated in .connect()
 
+        self.receive_timeout = 600
+
         # Table of Session entries, the order is important for smbclient.
         self.session_table = OrderedDict()
 
@@ -1306,7 +1308,7 @@ class Connection:
                 # safe choice.
                 # https://github.com/jborean93/smbprotocol/issues/31
                 try:
-                    b_msg = self.transport.recv(600)
+                    b_msg = self.transport.recv(self.receive_timeout)
                 except TimeoutError as ex:
                     # Check if the connection has unanswered keepalive echo requests with the reserved field set.
                     # When unanswered keep alive echo exists, the server did not respond withing two times the timeout.


### PR DESCRIPTION
This PR extends the configurability of the SMB Connection class and register_session methods to allow modifying the transport.recv timeout used for both keep-alive checks that keep Windows from closing a connection at ~16 minutes, and for checking the health of the connection.


In the usecase of my application, the SMB connection is used over an unstable network, which sometimes loses the connections between the machines. This triggers Connection timed out errors from the health check implemented in _process_message_thread, but only after 10+ minutes (the hardcoded timeout) where the application hangs. I would like to be able to configure this timeout to be smaller for use cases like this, to perform the health check more often, and be able to handle the timeout error in a reasonable ammount of time.


### Current behaviour:
- The connection is checked every 10 minutes using a SMB2_ECHO command.
- If the connection is broken due to a network problem, the connection will be stuck until the timeout passes, the ECHO command is sent and the server does not respond to it.

### Expected Behavior
- The timeout should be configurable for the cases where network errors are common, and handling them often requires waiting 10+ minutes for each such problem.


This might also be a fix for https://github.com/jborean93/smbprotocol/issues/117 (mentions a similar problem), by allowing configuring a smaller timeout value, which does not keep the application stuck for long and allows the error to be handled in my application in a timely manner. 

The PR extends the health checks added in https://github.com/jborean93/smbprotocol/pull/135 with the configurable health check interval value.
