### PR TITLE
Fix Impacket logoff session id check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.14.1 - TBD
+
+* Add workaround for Impackets logoff response not setting the session id for message verification
+* Remove connection from global connection cache even if failing to close it
+
 ## 1.14.0 - 2024-08-26
 
 * Dropped support for Python 3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smbprotocol"
-version = "1.14.0"
+version = "1.14.1"
 description = "Interact with a server using the SMB 2/3 Protocol"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/smbclient/_pool.py
+++ b/src/smbclient/_pool.py
@@ -440,10 +440,10 @@ def reset_connection_cache(fail_on_error=True, connection_cache=None):
     if connection_cache is None:
         connection_cache = _SMB_CONNECTIONS
 
-    for name, connection in list(connection_cache.items()):
+    for name in list(connection_cache.keys()):
+        connection = connection_cache.pop(name)
         try:
             connection.disconnect()
-            del connection_cache[name]
         except Exception as e:
             if fail_on_error:
                 raise


### PR DESCRIPTION
Fixes the session lookup logic when the logoff response contains a session id of 0. This occurs when using an Impacket server and will have the client just lookup the session id from the request.

Also adjusts the connection cache clearing behaviour to remove the connection from the cache regardless of the result of the disconnect behaviour.

Fixes: https://github.com/jborean93/smbprotocol/issues/289