### PR TITLE
Add `smbclient.liststreams` to enumerate ADS streams

### DIFF
--- a/src/smbclient/__init__.py
+++ b/src/smbclient/__init__.py
@@ -14,6 +14,7 @@ from smbclient._os import (
     getxattr,
     link,
     listdir,
+    liststreams,
     listxattr,
     lstat,
     makedirs,

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -834,10 +834,7 @@ def test_open_file_with_ads(smb_share):
 
     assert smbclient.listdir(smb_share) == ["file.txt"]
 
-    with smbclient.open_file(filename, buffering=0, mode="rb") as fd, SMBFileTransaction(fd) as trans:
-        query_info(trans, FileStreamInformation, output_buffer_length=1024)
-
-    actual = sorted([s["stream_name"].get_value() for s in trans.results[0]])
+    actual = sorted([s.name for s in smbclient.liststreams(filename)])
     assert actual == ["::$DATA", ":ads:$DATA"]
 
 


### PR DESCRIPTION
A simple change in theory, let me know if I messed up anything with layout / documentation etc.

I haven't got a huge array of machines to test against, but it works on my test device.

Closes #292