### PR TITLE
Fix TypeError: smbclient._io.SMBDirectoryIO() got multiple values for keyword argument 'share_access'

### DIFF
--- a/src/smbclient/_os.py
+++ b/src/smbclient/_os.py
@@ -684,7 +684,8 @@ def scandir(path, search_pattern="*", **kwargs):
     :return: An iterator of DirEntry objects in the directory.
     """
     connection_cache = kwargs.get("connection_cache", None)
-    with SMBDirectoryIO(path, share_access="rwd", **kwargs) as fd:
+    with SMBDirectoryIO(path, **kwargs) as fd:
+        kwargs.setdefault("share_access", "rwd")
         for raw_dir_info in fd.query_directory(search_pattern, FileInformationClass.FILE_ID_FULL_DIRECTORY_INFORMATION):
             filename = raw_dir_info["file_name"].get_value().decode("utf-16-le")
             if filename in [".", ".."]:


### PR DESCRIPTION
Switched 'share_access' to default kwarg in `scandir()` to avoid multiple values error.

There is probably a reason for this error but wanting to start a thread because this solution unblocks me currently from using `share_access` with high-level functions.