### PR TITLE
Allow floating point times for smbclient.utime

### DIFF
--- a/src/smbclient/_os.py
+++ b/src/smbclient/_os.py
@@ -945,8 +945,8 @@ def utime(path, times=None, ns=None, follow_symlinks=True, **kwargs):
         if times:
             time_tuple = times
 
-            # seconds in 100s of nanoseonds
-            op = operator.mul
+            # seconds in 100s of nanoseonds, may be float
+            op = lambda a, b: int(a * b)
             op_amt = 10000000
         else:
             time_tuple = ns

--- a/tests/test_smbclient_os.py
+++ b/tests/test_smbclient_os.py
@@ -1709,6 +1709,27 @@ def test_set_utime_file(smb_share):
 @pytest.mark.skipif(
     os.name != "nt" and not os.environ.get("SMB_FORCE", False), reason="Samba does not update timestamps"
 )
+def test_set_utime_float(smb_share):
+    filename = "%s\\file.txt" % smb_share
+
+    with smbclient.open_file(filename, mode="w") as fd:
+        fd.write("abc")
+
+    before_stat = smbclient.stat(filename)
+    smbclient.utime(filename, times=(1.0, 1.0))
+    actual = smbclient.stat(filename)
+
+    assert actual.st_atime == 1.0
+    assert actual.st_atime_ns == 1000000000
+    assert actual.st_ctime == before_stat.st_ctime
+    assert actual.st_ctime_ns == before_stat.st_ctime_ns
+    assert actual.st_mtime == 1.0
+    assert actual.st_mtime_ns == 1000000000
+
+
+@pytest.mark.skipif(
+    os.name != "nt" and not os.environ.get("SMB_FORCE", False), reason="Samba does not update timestamps"
+)
 def test_set_utime_file_negative(smb_share):
     filename = "%s\\file.txt" % smb_share
 


### PR DESCRIPTION
The doc for utime:
> If times is not None, it must be a 2-tuple of the form (atime, mtime) where each member is an int or float expressing seconds.

However, providing floats throws:
```
TypeError: Cannot parse value for field last_access_time of type float to an int
```

This fixes that and adds a unit test to verify.