### PR TITLE
Handle ECONNABORTED and avoid joining the current thread

### DIFF
--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -953,7 +953,7 @@ class Connection:
 
         log.info("Disconnecting transport connection")
         self.transport.close()
-        if self._t_worker:
+        if self._t_worker and self._t_worker.ident != threading.get_ident():
             self._t_worker.join(timeout=2)
 
     def send(

--- a/src/smbprotocol/transport.py
+++ b/src/smbprotocol/transport.py
@@ -145,7 +145,7 @@ class Tcp:
                 except OSError as e:
                     # Windows will raise this error if the socket has been shutdown, Linux return returns an empty byte
                     # string so we just replicate that.
-                    if e.errno not in [errno.ESHUTDOWN, errno.ECONNRESET]:
+                    if e.errno not in [errno.ESHUTDOWN, errno.ECONNRESET, errno.ECONNABORTED]:
                         # Avoid collecting coverage here to avoid CI failing due to race condition differences
                         raise  # pragma: no cover
                     b_data = b""


### PR DESCRIPTION
In windows the socket might also be terminated with `errno.ECONNABORTED`, and since `disconnect` can be called from the message thread we need to avoid `join` in that case
