### PR TITLE
Fix copy/copy2 kwargs handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Optimize `SMBDirEntry.is_symlink()`, returned by `smbclient.scandir()` to no longer require any extra SMB calls, this object is returned by APIs such as `
 * Raise exception when receiving an SMB `STATUS_STOPPED_ON_SYMLINK` response that contains no reparse buffer data
   * Some SMB servers like macOS do not return this information
+* Fix up `smbclient.shutil.copy` and `smbclient.shutil.copy2` to properly pass along the connection `kwargs` to the internal copy call
 
 ## 1.15.0 - 2024-11-12
 

--- a/src/smbclient/shutil.py
+++ b/src/smbclient/shutil.py
@@ -452,8 +452,8 @@ def _copy(src, dst, follow_symlinks, copy_meta_func, **kwargs):
     if (is_remote_path(ntpath.normpath(dst)) and isdir(dst, **kwargs)) or os.path.isdir(dst):
         dst = _join_local_or_remote_path(dst, _basename(src))
 
-    copyfile(src, dst, follow_symlinks=follow_symlinks)
-    copy_meta_func(src, dst, follow_symlinks=follow_symlinks)
+    copyfile(src, dst, follow_symlinks=follow_symlinks, **kwargs)
+    copy_meta_func(src, dst, follow_symlinks=follow_symlinks, **kwargs)
     return dst
 
 


### PR DESCRIPTION
Make sure that the kwargs for copy and copy2 are passed down to the underlying function that does the file and metadata copying.

Fixes: https://github.com/jborean93/smbprotocol/issues/330