### PR TITLE
Fix the str value for flag fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.17.0 - TBD
 
 * Drop support for Python 3.9, minimum verison if now 3.10
+* Added the `hostname_override` kwarg to `smbprotocol.Session` that can override the hostname used in the SPN for authentication
+* Correctly perform a DFS referral lookup in the `query_directory` on a directory
+* Fix the `FlagField` str representation when the `flag_type` contains a dunder attribute with an `int` value
 
 ## 1.16.1 - 2026-04-02
 

--- a/src/smbprotocol/structure.py
+++ b/src/smbprotocol/structure.py
@@ -797,7 +797,8 @@ class FlagField(IntField):
             return "0"
         flags = []
         for flag, value in vars(self.flag_type).items():
-            if isinstance(value, int) and self.has_flag(value):
+            # ignore and dunder __foo__ attributes.
+            if not flag.startswith("__") and isinstance(value, int) and self.has_flag(value):
                 flags.append(flag)
         flags.sort()
         return f"({field_value}) " + (", ".join(flags))

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1647,6 +1647,21 @@ class TestFlagField:
             field.set_value(0x00000082)
         assert str(exc.value) == "Invalid flag for field field value set 128"
 
+    def test_flag_str_ignores_dunder_attributes(self):
+        class MyClass:
+            __test__ = 3
+
+            FLAG1 = 1
+            FLAG2 = 2
+
+        expected = "(3) FLAG1, FLAG2"
+
+        field = FlagField(size=4, flag_type=MyClass)
+        field.set_value(3)
+        actual = str(field)
+
+        assert actual == expected
+
 
 class TestBoolField:
     class StructureTest(Structure):


### PR DESCRIPTION
Fixes the str value for a flag field with a dunder attribute `__foo__` that has an `int` value.

Adds some CHANGELOG entries for past commits.

Fixes: https://github.com/jborean93/smbprotocol/issues/347