### PR TITLE
Improve recv-path diagnostics

### DIFF
--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -1431,7 +1431,9 @@ class Connection:
                         if request.message["reserved"].get_value() == 1:
                             self.outstanding_requests.pop(message_id, None)
         except Exception as exc:
-            # The exception is raised in _check_worker_running by the main thread when send/receive is called next.
+            log.exception("SMB receive worker died (outstanding=%d)", len(self.outstanding_requests))
+
+            # The exception is raised in _check_worker_running by the caller thread when send/receive is called next.
             self._t_exc = exc
 
             # While a caller of send/receive could theoretically catch this exception, we consider any failures

--- a/src/smbprotocol/transport.py
+++ b/src/smbprotocol/transport.py
@@ -135,10 +135,10 @@ class Tcp:
                     return None, timeout  # pragma: no cover
 
                 read = select.select([self._sock], [], [], max(timeout, 1))[0]
-                timeout = timeout - (timeit.default_timer() - start_time)
+                elapsed = timeit.default_timer() - start_time
+                timeout = timeout - elapsed
                 if not read:
-                    log.debug("Socket recv(%s) timed out")
-                    raise TimeoutError()
+                    raise TimeoutError(f"recv idle for {elapsed:.1f}s ({offset}/{length} bytes)")
 
                 try:
                     b_data = self._sock.recv(read_len)
@@ -148,6 +148,10 @@ class Tcp:
                     if e.errno not in [errno.ESHUTDOWN, errno.ECONNRESET, errno.ECONNABORTED]:
                         # Avoid collecting coverage here to avoid CI failing due to race condition differences
                         raise  # pragma: no cover
+                    log.warning(
+                        "socket aborted by peer (%s), treating as EOF",
+                        errno.errorcode.get(e.errno, e.errno),
+                    )
                     b_data = b""
 
             read_len = len(b_data)


### PR DESCRIPTION
A bare TimeoutError from Tcp._recv carries no context about which recv fired or how many bytes had been consumed. The worker thread can die silently on any other Exception, leaving _t_exc to surface only on the next app call. Peer-aborted sockets (ESHUTDOWN, ECONNRESET, ECONNABORTED) are mapped to clean EOF with no log.