### PR TITLE
Fix signing requirement against signing required

### DIFF
--- a/src/smbprotocol/connection.py
+++ b/src/smbprotocol/connection.py
@@ -921,6 +921,7 @@ class Connection:
             SecurityMode.SMB2_NEGOTIATE_SIGNING_REQUIRED
         ):
             self.require_signing = True
+            self.client_security_mode = SecurityMode.SMB2_NEGOTIATE_SIGNING_REQUIRED
         log.info("Connection require signing: %s", self.require_signing)
 
         capabilities = smb_response["capabilities"]

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -987,7 +987,11 @@ class TestConnection:
             assert len(connection.salt) == 32
             assert connection.sequence_window["low"] == 1
             assert connection.sequence_window["high"] == 2
-            assert connection.client_security_mode == SecurityMode.SMB2_NEGOTIATE_SIGNING_ENABLED
+            assert (
+                connection.client_security_mode == SecurityMode.SMB2_NEGOTIATE_SIGNING_REQUIRED
+                if connection.server_security_mode & SecurityMode.SMB2_NEGOTIATE_SIGNING_REQUIRED
+                else SecurityMode.SMB2_NEGOTIATE_SIGNING_ENABLED
+            )
             assert connection.supports_encryption
 
             if connection.server_security_mode & SecurityMode.SMB2_NEGOTIATE_SIGNING_REQUIRED:


### PR DESCRIPTION
When using `smbprotocol`, with `require_signing=False` on the `Connection` class, against a computer requiring signing (a Domain Controller for example), the client fails to update its `client_security_mode` as stated in the [specification](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962) section 3.2.4.2.2.2.

<img width="678" height="97" alt="image" src="https://github.com/user-attachments/assets/2aaf77fb-bf69-42cd-b2c3-aa100bd79549" />

EDIT: force pushed to update test case that failed with the initial PR