### PR TITLE
Stop OSError leaks past rmtree's ignore_errors

### DIFF
--- a/src/smbclient/shutil.py
+++ b/src/smbclient/shutil.py
@@ -411,12 +411,13 @@ def rmtree(path, ignore_errors=False, onerror=None, **kwargs):
         def onerror(*args):
             raise
 
-    if islink(path, **kwargs):
-        try:
+    # islink issues SMB requests, so route failures through onerror.
+    try:
+        if islink(path, **kwargs):
             raise OSError("Cannot call rmtree on a symbolic link")
-        except OSError:
-            onerror(islink, path, sys.exc_info())
-            return
+    except OSError:
+        onerror(islink, path, sys.exc_info())
+        return
 
     scandir_gen = scandir(path, **kwargs)
     while True:

--- a/tests/test_smbclient_shutil.py
+++ b/tests/test_smbclient_shutil.py
@@ -1583,3 +1583,27 @@ def test_rmtree_symlink_as_dir(smb_share):
     assert callback_args[0][0].__name__ == "islink"
     assert callback_args[0][1] == dst_dirname
     assert isinstance(callback_args[0][2][1], OSError)
+
+
+def test_rmtree_islink_failure_invokes_onerror(mocker):
+    # islink issues SMB requests and can fail. Verify rmtree routes that failure
+    # through onerror so ignore_errors=True still suppresses it.
+    fake_path = r"\\server\share\dst"
+
+    def _failing_islink(*args, **kwargs):
+        raise SMBOSError(NtStatus.STATUS_DELETE_PENDING, fake_path)
+
+    _failing_islink.__name__ = "islink"
+    mocker.patch("smbclient.shutil.islink", new=_failing_islink)
+
+    # ignore_errors=True path: must not raise, must return cleanly.
+    rmtree(fake_path, ignore_errors=True)
+
+    # onerror path: callback receives (islink, path, exc_info).
+    callback_args = []
+    rmtree(fake_path, onerror=lambda *args: callback_args.append(args))
+
+    assert len(callback_args) == 1
+    assert callback_args[0][0].__name__ == "islink"
+    assert callback_args[0][1] == fake_path
+    assert isinstance(callback_args[0][2][1], SMBOSError)


### PR DESCRIPTION
rmtree's top-level islink probe ran outside any try-except, so an OSError there bypassed ignore_errors=True.
ignore_errors installs a no-op onerror, not a global suppressor, so any unguarded call reaches the caller.