### PR TITLE
Clear Open client state on close-response error

### DIFF
--- a/src/smbprotocol/open.py
+++ b/src/smbprotocol/open.py
@@ -1103,6 +1103,10 @@ class SMB2SetInfoResponse(Structure):
 
 
 class Open:
+    # MS-SMB2 3.2.4.1.4 ChainedFileId: 0xFF * 16 signals "use the Open
+    # from the most recent CREATE in this related-compound chain".
+    _RELATED_COMPOUND_FILE_ID = b"\xff" * 16
+
     def __init__(self, tree, name):
         """
         [MS-SMB2] v53.0 2017-09-15
@@ -1126,10 +1130,7 @@ class Open:
         self.file_attributes = None
 
         # properties used privately
-        # set to { 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF } to allow message
-        # compounding with the open as the first message, once opened this
-        # will be overwritten by the open response
-        self.file_id = b"\xff" * 16
+        self.file_id = self._RELATED_COMPOUND_FILE_ID
         self.tree_connect = tree
         self.connection = tree.session.connection
         self.oplock_level = None

--- a/src/smbprotocol/open.py
+++ b/src/smbprotocol/open.py
@@ -1597,28 +1597,29 @@ class Open:
         try:
             response = self.connection.receive(request)
         except FileClosed:
+            # already closed server-side
+            return
+        else:
+            c_resp = SMB2CloseResponse()
+            c_resp.unpack(response["data"].get_value())
+            log.debug(c_resp)
+
+            # update the attributes if requested
+            close_request = SMB2CloseRequest()
+            close_request.unpack(request.message["data"].get_value())
+            if close_request["flags"].has_flag(CloseFlags.SMB2_CLOSE_FLAG_POSTQUERY_ATTRIB):
+                self.creation_time = c_resp["creation_time"].get_value()
+                self.last_access_time = c_resp["last_access_time"].get_value()
+                self.last_write_time = c_resp["last_write_time"].get_value()
+                self.change_time = c_resp["change_time"].get_value()
+                self.allocation_size = c_resp["allocation_size"].get_value()
+                self.end_of_file = c_resp["end_of_file"].get_value()
+                self.file_attributes = c_resp["file_attributes"].get_value()
+            return c_resp
+        finally:
+            # file_id may be unregistered (unsent compound) or already removed by a prior close
             self._connected = False
             self.tree_connect.session.open_table.pop(self.file_id, None)
-            return
-
-        c_resp = SMB2CloseResponse()
-        c_resp.unpack(response["data"].get_value())
-        log.debug(c_resp)
-        self._connected = False
-        del self.tree_connect.session.open_table[self.file_id]
-
-        # update the attributes if requested
-        close_request = SMB2CloseRequest()
-        close_request.unpack(request.message["data"].get_value())
-        if close_request["flags"].has_flag(CloseFlags.SMB2_CLOSE_FLAG_POSTQUERY_ATTRIB):
-            self.creation_time = c_resp["creation_time"].get_value()
-            self.last_access_time = c_resp["last_access_time"].get_value()
-            self.last_write_time = c_resp["last_write_time"].get_value()
-            self.change_time = c_resp["change_time"].get_value()
-            self.allocation_size = c_resp["allocation_size"].get_value()
-            self.end_of_file = c_resp["end_of_file"].get_value()
-            self.file_attributes = c_resp["file_attributes"].get_value()
-        return c_resp
 
     def lock(self, locks, lsn=0, lsi=0, wait=True, send=True):
         """

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -23,7 +23,14 @@ from smbprotocol.create_contexts import (
     SMB2CreateResponseLeaseV2,
     SMB2CreateTimewarpToken,
 )
-from smbprotocol.exceptions import EndOfFile, SMBException, SMBUnsupportedFeature
+from smbprotocol.exceptions import (
+    EndOfFile,
+    FileClosed,
+    ObjectNameNotFound,
+    SMBException,
+    SMBResponseException,
+    SMBUnsupportedFeature,
+)
 from smbprotocol.file_info import (
     FileAttributes,
     FileEndOfFileInformation,
@@ -69,6 +76,16 @@ from smbprotocol.open import (
 )
 from smbprotocol.session import Session
 from smbprotocol.tree import TreeConnect
+
+
+@pytest.fixture
+def closing_open(mocker):
+    """Open-shaped mock with the state `_close_response` mutates."""
+    open_obj = mocker.MagicMock()
+    open_obj._connected = True
+    open_obj.file_id = mocker.sentinel.file_id
+    open_obj.tree_connect.session.open_table = {open_obj.file_id: open_obj}
+    return open_obj
 
 
 class TestSMB2CreateRequest:
@@ -2534,3 +2551,47 @@ class TestOpen:
 
         finally:
             connection.disconnect(True)
+
+    def test_close_response_marks_disconnected_on_receive_failure(self, closing_open, mocker):
+        closing_open.connection.receive.side_effect = ObjectNameNotFound()
+
+        with pytest.raises(SMBResponseException):
+            Open._close_response(closing_open, mocker.MagicMock())
+
+        assert not closing_open._connected
+        assert not closing_open.tree_connect.session.open_table
+
+    def test_close_response_marks_disconnected_on_file_closed(self, closing_open, mocker):
+        closing_open.connection.receive.side_effect = FileClosed()
+
+        assert Open._close_response(closing_open, mocker.MagicMock()) is None
+        assert not closing_open._connected
+        assert not closing_open.tree_connect.session.open_table
+
+    def test_close_response_marks_disconnected_on_success(self, closing_open, mocker):
+        closing_open.connection.receive.return_value = mocker.MagicMock()
+        mocker.patch("smbprotocol.open.SMB2CloseResponse")
+        close_req_cls = mocker.patch("smbprotocol.open.SMB2CloseRequest")
+        close_req_cls.return_value.__getitem__.return_value.has_flag.return_value = False
+
+        Open._close_response(closing_open, mocker.MagicMock())
+
+        assert not closing_open._connected
+        assert not closing_open.tree_connect.session.open_table
+
+    def test_close_response_tolerates_already_popped_entry_on_receive_failure(self, closing_open, mocker):
+        closing_open.tree_connect.session.open_table.clear()
+        closing_open.connection.receive.side_effect = ObjectNameNotFound()
+
+        with pytest.raises(SMBResponseException):
+            Open._close_response(closing_open, mocker.MagicMock())
+
+        assert not closing_open._connected
+
+    def test_close_response_tolerates_already_popped_entry_on_file_closed(self, closing_open, mocker):
+        closing_open.tree_connect.session.open_table.clear()
+        closing_open.connection.receive.side_effect = FileClosed()
+
+        Open._close_response(closing_open, mocker.MagicMock())
+
+        assert not closing_open._connected


### PR DESCRIPTION
When receive() raised anything other than FileClosed, the
old close path propagated the exception with _connected still
True and the file_id still in session.open_table. A
subsequent close() reissued SMB CLOSE on a dead file_id, and
session.disconnect(close=True) walked the stale entry.
