### PR TITLE
Make codecov project status non-blocking on PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
The project status flips between pass and fail on the sub-percent coverage wobble from the live-server tests, blocking merges on noise rather than on untested code.