### PR TITLE
Move dev dependencies into pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,9 @@ by running;
 ```bash
 # Install in current environment.
 # Recommend to have virtual environment installed at .venv path.
-pip install -r requirements-dev.txt
-pip install -e .
+# Dependency groups need pip 25.1+.
+python -m pip install "pip>=25.1"
+pip install -e . --group dev
 ```
 
 From there to run the basic tests run;

--- a/build_helpers/lib.sh
+++ b/build_helpers/lib.sh
@@ -64,7 +64,9 @@ lib::setup::python_requirements() {
         --verbose
 
     echo "Installing dev dependencies"
-    python -m pip install -r requirements-dev.txt
+    # --group needs pip 25.1+ (PEP 735)
+    python -m pip install "pip>=25.1"
+    python -m pip install --group dev
 
     if [ x"${GITHUB_ACTIONS}" = "xtrue" ]; then
         echo "::endgroup::"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,22 @@ kerberos = ["pyspnego[kerberos]"]
 [project.urls]
 homepage = "https://github.com/jborean93/smbprotocol"
 
+[dependency-groups]
+test = [
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+]
+lint = [
+    "black == 26.3.1",
+    "isort == 8.0.1",
+    "pre-commit",
+]
+dev = [
+    {include-group = "test"},
+    {include-group = "lint"},
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
-black == 26.3.1
-build
-cryptography >= 2.0
-isort == 8.0.1
-pre-commit
-pyspnego
-pytest
-pytest-cov
-pytest-mock


### PR DESCRIPTION
The requirements file was the only dependency list outside the project metadata. cryptography and pyspnego only duplicated runtime dependencies, and build is a release tool CI installs separately.